### PR TITLE
Allow the CSS URL for annotations to be set via reader_views updateSettings functionality.

### DIFF
--- a/js/views/annotations_manager.js
+++ b/js/views/annotations_manager.js
@@ -106,6 +106,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj) {
     var liveAnnotations = {};
     var spines = {};
     var proxy = proxyObj; 
+    var annotationCSSUrl;
 
     _.extend(self, Backbone.Events);
 
@@ -134,7 +135,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj) {
 
     this.attachAnnotations = function($iframe, spineItem) {
         var epubDocument = $iframe[0].contentDocument;
-        liveAnnotations[spineItem.index] = new EpubAnnotationsModule(epubDocument, self);
+        liveAnnotations[spineItem.index] = new EpubAnnotationsModule(epubDocument, self, self.annotationCSSUrl);
         spines[spineItem.index] = spineItem;
 
         // check to see which spine indecies can be culled depending on the distance from current spine item
@@ -191,6 +192,10 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj) {
         }
         return result;
     };
+
+    this.updateSettings = function(updateData) {
+        self.annotationCSSUrl = updateData.annotationCSSUrl;
+    }
 
 
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -272,6 +272,9 @@ ReadiumSDK.Views.ReaderView = function(options) {
 //console.debug("UpdateSettings: " + JSON.stringify(settingsData));
 
         _viewerSettings.update(settingsData);
+        
+        _annotationsManager && _annotationsManager.updateSettings(settingsData);
+
 
         if(_currentView && !settingsData.doNotUpdateView) {
 

--- a/lib/annotations_module.js
+++ b/lib/annotations_module.js
@@ -190,7 +190,6 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     },
 
     initialize : function (attributes, options) {
-
         this.set("scale", attributes.scale);
         this.constructHighlightViews();
     },
@@ -519,7 +518,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             offsetTopAddition : 0, 
             offsetLeftAddition : 0, 
             readerBoundElement : $("html", this.get("contentDocumentDOM"))[0],
-            scale: 0, 
+            scale: 0,
             bbPageSetView : this.get("bbPageSetView")
         });
         // inject annotation CSS into iframe 
@@ -531,6 +530,9 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         var self = this;
         epubWindow.on("mouseup", function(event) {
             var range = self.getCurrentSelectionRange();
+            if (range === undefined) {
+                return;
+            }
             if (range.startOffset - range.endOffset) {
                 self.annotations.get("bbPageSetView").trigger("textSelectionEvent", event);
             }
@@ -566,11 +568,11 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         var startMarkerHtml = this.getRangeStartMarker(CFI, id);
         var endMarkerHtml = this.getRangeEndMarker(CFI, id);
 
+        // TODO webkit specific?
         var $html = $(this.get("contentDocumentDOM"));
         var matrix = $('html', $html).css('-webkit-transform');
-        var scale = new WebKitCSSMatrix(matrix).a; 
+        var scale = new WebKitCSSMatrix(matrix).a;
         this.set("scale", scale);
-
 
         try {
             CFIRangeInfo = this.epubCFI.injectRangeElements(
@@ -713,7 +715,6 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             selectionInfo = this.getSelectionInfo(currentSelection);
             generatedContentDocCFI = selectionInfo.CFI;
             CFI = "epubcfi(" + arbitraryPackageDocCFI + generatedContentDocCFI + ")";
-
             if (type === "highlight") {
                 annotationInfo = this.addHighlight(CFI, id, type, styles);
             }
@@ -1590,7 +1591,7 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
     var reflowableAnnotations = new EpubAnnotations.ReflowableAnnotations({
         contentDocumentDOM : contentDocumentDOM, 
         bbPageSetView : bbPageSetView,
-        annotationCSSUrl : "/css/annotations.css"
+        annotationCSSUrl : annotationCSSUrl || "/css/annotations.css"
     });
 
     // Description: The public interface


### PR DESCRIPTION
The CSS can be set with annotationCSSUrl key:

```
readium.reader.updateSettings({'annotationCSSUrl': '/asdfasdf/'})
```

Note this only works on the next iframe load.
