### PR TITLE
Allow the CSS URL for annotations to be specified via an option has to the reader_view constructor

### DIFF
--- a/js/views/annotations_manager.js
+++ b/js/views/annotations_manager.js
@@ -100,13 +100,17 @@ Then when the user clicks on the highlight the following will show up in the con
 */
 
 
-ReadiumSDK.Views.AnnotationsManager = function (proxyObj) {
+ReadiumSDK.Views.AnnotationsManager = function (proxyObj, options) {
 
     var self = this;
     var liveAnnotations = {};
     var spines = {};
     var proxy = proxyObj; 
-    var annotationCSSUrl;
+    var annotationCSSUrl = options.annotationCSSUrl;
+
+    if (!annotationCSSUrl) {
+        console.warn("WARNING! Annotations CSS not supplied. Highlighting is not going to work.");
+    }
 
     _.extend(self, Backbone.Events);
 
@@ -135,7 +139,7 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj) {
 
     this.attachAnnotations = function($iframe, spineItem) {
         var epubDocument = $iframe[0].contentDocument;
-        liveAnnotations[spineItem.index] = new EpubAnnotationsModule(epubDocument, self, self.annotationCSSUrl);
+        liveAnnotations[spineItem.index] = new EpubAnnotationsModule(epubDocument, self, annotationCSSUrl);
         spines[spineItem.index] = spineItem;
 
         // check to see which spine indecies can be culled depending on the distance from current spine item
@@ -192,10 +196,6 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj) {
         }
         return result;
     };
-
-    this.updateSettings = function(updateData) {
-        self.annotationCSSUrl = updateData.annotationCSSUrl;
-    }
 
 
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -40,7 +40,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
     var _mediaOverlayDataInjector;
     var _iframeLoader;
     var _$el;
-    var _annotationsManager;
+    var _annotationsManager = new ReadiumSDK.Views.AnnotationsManager(self, options);
     
     if (options.el instanceof $) {
         _$el = options.el;
@@ -89,6 +89,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
 
             _currentView = new ReadiumSDK.Views.FixedView(viewCreationParams);
         }
+
 
         _currentView.setViewSettings(_viewerSettings);
 
@@ -182,7 +183,6 @@ ReadiumSDK.Views.ReaderView = function(options) {
 
         _mediaOverlayDataInjector = new ReadiumSDK.Views.MediaOverlayDataInjector(_package.media_overlay, _mediaOverlayPlayer);
 
-        _annotationsManager = new ReadiumSDK.Views.AnnotationsManager(self);
 
         resetCurrentView();
 
@@ -273,9 +273,6 @@ ReadiumSDK.Views.ReaderView = function(options) {
 
         _viewerSettings.update(settingsData);
         
-        _annotationsManager && _annotationsManager.updateSettings(settingsData);
-
-
         if(_currentView && !settingsData.doNotUpdateView) {
 
             var bookMark = _currentView.bookmarkCurrentPage();

--- a/lib/annotations_module.js
+++ b/lib/annotations_module.js
@@ -523,7 +523,12 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         });
         // inject annotation CSS into iframe 
 
-        this.injectAnnotationCSS(this.get("annotationCSSUrl"));
+        
+        var annotationCSSUrl = this.get("annotationCSSUrl");
+        if (annotationCSSUrl)
+        {
+            this.injectAnnotationCSS(annotationCSSUrl);
+        }
 
         // emit an event when user selects some text.
         var epubWindow = $(this.get("contentDocumentDOM"));
@@ -1591,7 +1596,7 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
     var reflowableAnnotations = new EpubAnnotations.ReflowableAnnotations({
         contentDocumentDOM : contentDocumentDOM, 
         bbPageSetView : bbPageSetView,
-        annotationCSSUrl : annotationCSSUrl || "/css/annotations.css"
+        annotationCSSUrl : annotationCSSUrl,
     });
 
     // Description: The public interface


### PR DESCRIPTION
Previously, annotations' CSS file was hardcoded inside the annotation library. This changeset allows the client to specify the annotations CSS via an options hash passed to the reader.

This changeset includes an associated change to readium-js and readium-js-viewer as well.
