### PR TITLE
Expose the current spine item using a getCurrentSpineItem() getter method on reflowable, scrollable and one page views.

### DIFF
--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -242,6 +242,10 @@ ReadiumSDK.Views.OnePageView = function(options){
         return undefined;
     }
 
+    this.getCurrentSpineItem = function() {
+        return _currentSpineItem;
+    };
+
     this.getFirstVisibleElementCfi = function(){
 
         var navigation = new ReadiumSDK.Views.CfiNavigationLogic(_$el, _$iframe);

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -521,6 +521,10 @@ ReadiumSDK.Views.ReflowableView = function(options){
 
     };
 
+    this.getCurrentSpineItem = function() {
+        return _currentSpineItem;
+    };
+
     function getOpenPageIndexes() {
 
         var indexes = [];

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -476,6 +476,9 @@ ReadiumSDK.Views.ScrollView = function(options){
 
     };
 
+    this.getCurrentSpineItem = function() {
+        return _currentSpineItem;
+    };
 
     this.bookmarkCurrentPage = function() {
 


### PR DESCRIPTION
Hi!

The refactoring introduced in commit d61e9e5 has broken readium-js which accessed the `currentSpineItem` property of the view directly from the `iframe_zip_loader`. 

Since `_currentSpineItem` is a private property now, I've added a getter method so that it remains accessible to readium-js.
