### PR TITLE
Cross-browser navigation logic for reflowable view

### DIFF
--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -330,6 +330,9 @@ ReadiumSDK.Views.ReflowableView = function(options){
             _paginationInfo.currentSpreadIndex = Math.floor(pageIndex / _paginationInfo.visibleColumnCount) ;
             onPaginationChanged(pageRequest.initiator, pageRequest.spineItem, pageRequest.elementId);
         }
+        else {
+            console.log('Illegal pageIndex value: ', pageIndex, 'column count is ', _paginationInfo.columnCount);
+        }
     };
 
     function redraw() {
@@ -472,7 +475,8 @@ ReadiumSDK.Views.ReflowableView = function(options){
         //we do this because CSS will floor column with by itself if it is not a round number
         _paginationInfo.columnWidth = Math.floor(_paginationInfo.columnWidth);
 
-        _$epubHtml.css("width", _paginationInfo.columnWidth);
+        // _$epubHtml.css("width", _paginationInfo.columnWidth);
+        _$epubHtml.css("width", _lastViewPortSize.width);
 
         hideBook(); // shiftBookOfScreen();
 


### PR DESCRIPTION
Reflowable view now uses Rectangle-based methods of CfiNavigationLogic to handle different rendering engines (WebKit, Blink, Gecko, Trident) in uniform way.
Rectangle-based methods of CfiNavigationLogic are used for 
1) Retrieving of all currently visible elements
2) Find first visible element
3) Checking visibility of element
4) Calculating of page index of given element

TODO:
- Custom CFI extension introduced in CfiNavigationLogic and related to percentage of visibility should be reviewed for robustness of positioning. This is actual especially for different viewports.
- Rectangle-based methods of CfiNavigationLogic should be adjusted to support right-to-left books.
