### PR TITLE
jQuery automatically adds prefix to css rules

### DIFF
--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -76,13 +76,12 @@ ReadiumSDK.Views.FixedView = function(options){
         var template = ReadiumSDK.Helpers.loadTemplate("fixed_book_frame", {});
 
         _$el = $(template);
-        
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            _$el.css(prefix + "transition", "all 0 ease 0");
+
+        _$el.css({
+          transition: "all 0 ease 0",
+          overflow: "hidden"
         });
-        
-        _$el.css("overflow", "hidden");
-        
+
         _$viewport.append(_$el);
 
         self.applyStyles();
@@ -134,7 +133,7 @@ ReadiumSDK.Views.FixedView = function(options){
 // console.error("updatePageSwitchDir");
 // console.log(dir);
 // console.log(hasChanged);
-// 
+//
         // irrespective of display state
         if (_leftPageView) _leftPageView.pageSwitchDir(dir, hasChanged);
         if (_rightPageView) _rightPageView.pageSwitchDir(dir, hasChanged);
@@ -145,7 +144,7 @@ ReadiumSDK.Views.FixedView = function(options){
         //     views[i].pageSwitchDir(dir, hasChanged);
         // }
     };
-    
+
 
     this.applyStyles = function() {
 
@@ -292,7 +291,7 @@ ReadiumSDK.Views.FixedView = function(options){
 
         if(bookLeft < 0) bookLeft = 0;
         if(bookTop < 0) bookTop = 0;
-        
+
         _$el.css("left", bookLeft + "px");
         _$el.css("top", bookTop + "px");
         _$el.css("width", targetElementSize.width + "px");
@@ -403,12 +402,12 @@ ReadiumSDK.Views.FixedView = function(options){
         var leftItem = _spread.leftItem;
         var rightItem = _spread.rightItem;
         var centerItem = _spread.centerItem;
-        
+
         _spread.openItem(paginationRequest.spineItem);
-        
+
         var hasChanged = leftItem !== _spread.leftItem || rightItem !== _spread.rightItem || centerItem !== _spread.centerItem;
         updatePageSwitchDir(dir === 0 ? 0 : (_spread.spine.isRightToLeft() ? (dir === 1 ? 2 : 1) : dir), hasChanged);
-        
+
         redraw(paginationRequest.initiator, paginationRequest);
     };
 
@@ -558,7 +557,7 @@ ReadiumSDK.Views.FixedView = function(options){
         console.error("spine item is not loaded");
         return undefined;
     };
-    
+
     this.getElementByCfi = function(spineItem, cfi, classBlacklist, elementBlacklist, idBlacklist) {
 
         var views = getDisplayingViews();

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -41,7 +41,7 @@ ReadiumSDK.Views.OnePageView = function(options){
         width: 0,
         height: 0
     };
-    
+
     var _pageSwitchDir = 0; // 0 => stay on same page, 1 => previous, 2 => next
     var _pageSwitchActuallyChanged = false;
     var _pageSwitchActuallyChanged_IFRAME_LOAD = false;
@@ -52,11 +52,11 @@ ReadiumSDK.Views.OnePageView = function(options){
 //console.error("pageSwitchDir _pageSwitchActuallyChanged_IFRAME_LOAD SKIP");
             return;
         }
-        
+
         _pageSwitchDir = dir;
         _pageSwitchActuallyChanged = hasChanged;
     };
-    
+
 
     this.element = function() {
         return _$el;
@@ -82,13 +82,12 @@ ReadiumSDK.Views.OnePageView = function(options){
             var template = ReadiumSDK.Helpers.loadTemplate("fixed_page_frame", {});
 
             _$el = $(template);
-        
-            _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                _$el.css(prefix + "transition", "all 0 ease 0");
+
+            _$el.css({
+              transition: "all 0 ease 0",
+              height: "100%",
+              width: "100%"
             });
-        
-            _$el.css("height", "100%");
-            _$el.css("width", "100%");
 
             _$el.addClass(options.class);
             _$iframe = $("iframe", _$el);
@@ -118,38 +117,36 @@ ReadiumSDK.Views.OnePageView = function(options){
             _$epubHtml.css("overflow", "hidden");
             self.applyBookStyles();
             updateMetaSize();
-            
+
             _pageSwitchActuallyChanged_IFRAME_LOAD = true; // second pass, but initial display for transition
-            
+
             self.trigger(ReadiumSDK.Views.OnePageView.SPINE_ITEM_OPENED, _$iframe, _currentSpineItem, self);
         }
     }
 
     this.applyBookStyles = function() {
-        
+
         //TODO: code refactoring candidate? (no CSS override for fixed-layout content, publishers do not like when reading systems mess-up their design)
         return;
-        
+
         if(_$epubHtml) {
             ReadiumSDK.Helpers.setStyles(_bookStyles.getStyles(), _$epubHtml);
         }
     };
-    
+
     this.transformContentImmediate = function(scale, left, top) {
-        
+
         var pageTransition_Translate = false; // TODO: from options
-        
+
         var pageSwitchActuallyChanged = _pageSwitchActuallyChanged || _pageSwitchActuallyChanged_IFRAME_LOAD;
         _pageSwitchActuallyChanged_IFRAME_LOAD = false;
 // console.error("transformContent: "+pageSwitchActuallyChanged + " - " + _pageSwitchDir);
 
         var elWidth = Math.ceil(_meta_size.width * scale);
         var elHeight = Math.floor(_meta_size.height * scale);
-    
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            _$el.css(prefix + "transition", "all 0 ease 0");
-        });
-    
+
+        _$el.css("transition", "all 0 ease 0");
+
         if (pageSwitchActuallyChanged && _enablePageTransitions)
         {
             if (_pageSwitchDir === 0)
@@ -170,12 +167,12 @@ ReadiumSDK.Views.OnePageView = function(options){
                 }
             }
         }
-        
+
         _$el.css("left", left + "px");
         _$el.css("top", top + "px");
         _$el.css("width", elWidth + "px");
         _$el.css("height", elHeight + "px");
-                                                    
+
         _$iframe.css("width", elWidth + "px");
         _$iframe.css("height", elHeight + "px");
 
@@ -195,50 +192,43 @@ ReadiumSDK.Views.OnePageView = function(options){
         _$epubHtml.css("opacity", "0.999");
 
         _$iframe.css("visibility", "visible");
-        
+
         setTimeout(function()
         {
             //_$epubHtml.css("visibility", "visible");
             _$epubHtml.css("opacity", "1");
         }, 0);
-        
+
         if (pageSwitchActuallyChanged && _enablePageTransitions)
         {
             setTimeout(function()
             {
                 if (_pageSwitchDir === 0)
                 {
-                    _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                        _$el.css(prefix + "transition", "opacity 250ms linear");
+                    _$el.css({
+                      transition: "opacity 250ms linear",
+                      opacity:"1"
                     });
-        
-                    _$el.css("opacity", "1");
                 }
                 else
                 {
                     if (pageTransition_Translate)
                     {
                         _$el.css("-webkit-transition", "-webkit-transform 200ms ease-out");
-                        var css = {};
-                        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                            //css[prefix + 'transition'] = prefix + "transform 200ms ease-out";
-                            css[prefix + 'transform'] = "none";
-                        });
-                        _$el.css(css);
+                        _$el.css("transform", "none");
                     }
                     else
                     {
-                        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                            _$el.css(prefix + "transition", "opacity 150ms ease-out");
+                        _$el.css({
+                          transition: "opacity 150ms ease-out",
+                          opacity: "1"
                         });
-
-                        _$el.css("opacity", "1");
                     }
                 }
 
                 // var moveBack = generateTransformCSS(0, 0, 0);
                 // _$el.css(css);
-                //             
+                //
                 //_$el.css("left", left + "px");
 
             }, 10);
@@ -250,19 +240,16 @@ ReadiumSDK.Views.OnePageView = function(options){
 
         var translate = (left !== 0 || top !== 0) ? "translate(" + left + "px, " + top + "px)" : undefined;
         var scale = scale !== 1 ? "scale(" + scale + ")" : undefined;
-        
+
         if (!(translate || scale)) return {};
-        
+
         var transformString = (translate && scale) ? (translate + " " + scale) : (translate ? translate : scale); // the order is important!
 
         //TODO modernizer library can be used to get browser independent transform attributes names (implemented in readium-web fixed_layout_book_zoomer.js)
-        var css = {};
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            css[prefix + 'transform'] = transformString;
-            css[prefix + 'transform-origin'] = '0 0';
-        });
-
-        return css;
+        return {
+          transform: transformString,
+          'transform-origin': '0 0'
+        };
     }
 
     function updateMetaSize() {
@@ -288,7 +275,7 @@ ReadiumSDK.Views.OnePageView = function(options){
             }
         }
         else { //try to get direct svg or image size
-            
+
             // try SVG element's width/height first
             var $svg = $(contentDocument).find('svg');
             if ($svg.length > 0) {

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -28,15 +28,15 @@ ReadiumSDK.Views.ReflowableView = function(options){
     _.extend(this, Backbone.Events);
 
     var self = this;
-    
+
     var _$viewport = options.$viewport;
     var _spine = options.spine;
     var _userStyles = options.userStyles;
     var _bookStyles = options.bookStyles;
     var _iframeLoader = options.iframeLoader;
-    
+
     var _currentSpineItem;
-    var _isWaitingFrameRender = false;    
+    var _isWaitingFrameRender = false;
     var _deferredPageRequest;
     var _fontSize = 100;
     var _$contentFrame;
@@ -168,7 +168,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
             self.trigger(ReadiumSDK.Events.CONTENT_DOCUMENT_LOAD_START, _$iframe, spineItem);
 
             _$iframe.css("opacity", "0.01");
-            
+
             _iframeLoader.loadIframe(_$iframe[0], src, onIFrameLoad, self, {spineItem : spineItem});
         }
     }
@@ -183,10 +183,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
     function updateColumnGap() {
 
         if(_$epubHtml) {
-        
-            _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-                _$epubHtml.css(prefix + "column-gap", _paginationInfo.columnGap + "px");
-            });
+          _$epubHtml.css("column-gap", _paginationInfo.columnGap + "px");
         }
     }
 
@@ -214,11 +211,10 @@ ReadiumSDK.Views.ReflowableView = function(options){
         hideBook();
         _$iframe.css("opacity", "1");
 
-        _$epubHtml.css("height", _lastViewPortSize.height + "px");
-        _$epubHtml.css("position", "relative");
-
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            _$epubHtml.css(prefix + "column-axis", "horizontal");
+        _$epubHtml.css({
+          height: _lastViewPortSize.height + "px",
+          position:"relative",
+          "column-axis": "horizontal"
         });
 
         self.applyBookStyles();
@@ -230,7 +226,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
 
 /////////
 //Columns Debugging
-// 
+//
 // _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
 //     _$epubHtml.css(prefix + "column-rule-color", "red");
 //     _$epubHtml.css(prefix + "column-rule-style", "dashed");
@@ -428,20 +424,18 @@ ReadiumSDK.Views.ReflowableView = function(options){
         _paginationInfo.columnWidth = Math.floor(_paginationInfo.columnWidth);
 
         // _$epubHtml.css("width", _paginationInfo.columnWidth);
-        _$epubHtml.css("width", _lastViewPortSize.width);
-
-        _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
-            _$epubHtml.css(prefix + "column-width", _paginationInfo.columnWidth + "px");
+        _$epubHtml.css({
+          width: _lastViewPortSize.width,
+          "column-width": _paginationInfo.columnWidth + "px"
         });
 
-
         var doc = _$iframe[0].contentDocument;
-	    var el = doc.createElementNS("http://www.w3.org/1999/xhtml", "style");
-	    el.appendChild(doc.createTextNode("*{}"));
-	    doc.body.appendChild(el);
-	    doc.body.removeChild(el);
-	    var blocking = doc.body.offsetTop; // browser rendering / layout done
-        
+        var el = doc.createElementNS("http://www.w3.org/1999/xhtml", "style");
+        el.appendChild(doc.createTextNode("*{}"));
+        doc.body.appendChild(el);
+        doc.body.removeChild(el);
+        var blocking = doc.body.offsetTop; // browser rendering / layout done
+
         // resetting the position
         _$epubHtml.css({left: 0, right: 0});
 
@@ -463,7 +457,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
         else {
 
             //we get here on resizing the viewport
-            
+
             onPaginationChanged(self); // => redraw() => showBook(), so the trick below is not needed
 
             // //We do this to force re-rendering of the document in the iframe.
@@ -491,7 +485,7 @@ ReadiumSDK.Views.ReflowableView = function(options){
     function hideBook()
     {
         if (_currentOpacity != -1) return; // already hidden
-        
+
         _currentOpacity = _$epubHtml.css('opacity');
         _$epubHtml.css('opacity', 0);
     }
@@ -658,13 +652,13 @@ ReadiumSDK.Views.ReflowableView = function(options){
 
         var openPageRequest = new ReadiumSDK.Models.PageOpenRequest(_currentSpineItem, initiator);
         openPageRequest.setPageIndex(page);
-        
+
         var id = element.id;
         if (!id)
         {
             id = element.getAttribute("id");
         }
-        
+
         if (id)
         {
             openPageRequest.setElementId(id);

--- a/lib/annotations_module.js
+++ b/lib/annotations_module.js
@@ -1,5 +1,5 @@
 var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotationCSSUrl) {
-    
+
     var EpubAnnotations = {};
 
     // Rationale: The order of these matters
@@ -30,10 +30,10 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
                 if (this.includeRectInLine(currLine, currRect.top, currRect.left, currRect.width, currRect.height)) {
                     this.expandLine(currLine, currRect.left, currRect.top, currRect.width, currRect.height);
                     rectAppended = true;
-                    break;   
+                    break;
                 }
-            } 
-            
+            }
+
             if (rectAppended) {
                 continue;
             }
@@ -118,8 +118,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         return {
             left : rectLeft,
             startTop : rectTop,
-            width : rectWidth, 
-            avgHeight : rectHeight, 
+            width : rectWidth,
+            avgHeight : rectHeight,
             maxTop : rectTop,
             maxBottom : maxBottom,
             numRects : 1
@@ -128,7 +128,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
     expandLine : function (currLine, rectLeft, rectTop, rectWidth, rectHeight) {
 
-        var lineOldRight = currLine.left + currLine.width; 
+        var lineOldRight = currLine.left + currLine.width;
 
         // Update all the properties of the current line with rect dimensions
         var rectRight = rectLeft + rectWidth;
@@ -143,7 +143,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         // Expand the line vertically
         currLine = this.expandLineVertically(currLine, rectTop, rectBottom);
-        currLine = this.expandLineHorizontally(currLine, rectLeft, rectRight);        
+        currLine = this.expandLineHorizontally(currLine, rectLeft, rectRight);
 
         return currLine;
     },
@@ -152,7 +152,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         if (rectTop < currLine.maxTop) {
             currLine.maxTop = rectTop;
-        } 
+        }
         if (rectBottom > currLine.maxBottom) {
             currLine.maxBottom = rectBottom;
         }
@@ -199,7 +199,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     highlightGroupCallback : function (event) {
 
         var that = this;
-        
+
         // Trigger this event on each of the highlight views (except triggering event)
         if (event.type === "click") {
             that.get("bbPageSetView").trigger("annotationClicked", "highlight", that.get("CFI"), that.get("id"), event);
@@ -218,7 +218,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         _.each(this.get("highlightViews"), function (highlightView) {
 
             if (event.type === "mouseenter") {
-                highlightView.setHoverHighlight();    
+                highlightView.setHoverHighlight();
             }
             else if (event.type === "mouseleave") {
                 highlightView.setBaseHighlight();
@@ -287,8 +287,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         this.renderHighlights(viewportElement);
     },
 
-    // REFACTORING CANDIDATE: Ensure that event listeners are being properly cleaned up. 
-    destroyCurrentHighlights : function () { 
+    // REFACTORING CANDIDATE: Ensure that event listeners are being properly cleaned up.
+    destroyCurrentHighlights : function () {
 
         _.each(this.get("highlightViews"), function (highlightView) {
             highlightView.remove();
@@ -431,8 +431,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         this.renderUnderlines(viewportElement);
     },
 
-    // REFACTORING CANDIDATE: Ensure that event listeners are being properly cleaned up. 
-    destroyCurrentUnderlines : function () { 
+    // REFACTORING CANDIDATE: Ensure that event listeners are being properly cleaned up.
+    destroyCurrentUnderlines : function () {
 
         _.each(this.get("underlineViews"), function (underlineView) {
             underlineView.remove();
@@ -460,7 +460,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     },
 
     setStyles : function (styles) {
-        
+
         var underlineViews = this.get('underlineViews');
 
         this.set({styles : styles});
@@ -512,18 +512,18 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     EpubAnnotations.ReflowableAnnotations = Backbone.Model.extend({
 
     initialize : function (attributes, options) {
-        
+
         this.epubCFI = EPUBcfi;
         this.annotations = new EpubAnnotations.Annotations({
-            offsetTopAddition : 0, 
-            offsetLeftAddition : 0, 
+            offsetTopAddition : 0,
+            offsetLeftAddition : 0,
             readerBoundElement : $("html", this.get("contentDocumentDOM"))[0],
             scale: 0,
             bbPageSetView : this.get("bbPageSetView")
         });
-        // inject annotation CSS into iframe 
+        // inject annotation CSS into iframe
 
-        
+
         var annotationCSSUrl = this.get("annotationCSSUrl");
         if (annotationCSSUrl)
         {
@@ -592,7 +592,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
             // Get start and end marker for the id, using injected into elements
             // REFACTORING CANDIDATE: Abstract range creation to account for no previous/next sibling, for different types of
-            //   sibiling, etc. 
+            //   sibiling, etc.
             rangeStartNode = CFIRangeInfo.startElement.nextSibling ? CFIRangeInfo.startElement.nextSibling : CFIRangeInfo.startElement;
             rangeEndNode = CFIRangeInfo.endElement.previousSibling ? CFIRangeInfo.endElement.previousSibling : CFIRangeInfo.endElement;
             range = document.createRange();
@@ -611,7 +611,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             }
 
             return {
-                CFI : CFI, 
+                CFI : CFI,
                 selectedElements : selectionInfo.selectedElements
             };
 
@@ -643,7 +643,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
             return {
 
-                CFI : CFI, 
+                CFI : CFI,
                 selectedElements : $injectedElement[0]
             };
 
@@ -670,7 +670,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
             return {
 
-                CFI : CFI, 
+                CFI : CFI,
                 selectedElements : $targetImage[0]
             };
 
@@ -727,11 +727,11 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
                 annotationInfo = this.addHighlight(CFI, id, type, styles);
             }
 
-            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of 
+            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of
             //   the CFI variable in the current scope. Since this CFI variable contains a "hacked" CFI value -
             //   only the content document portion is valid - we want to replace the annotationInfo.CFI property with
             //   the partial content document CFI portion we originally generated.
-            annotationInfo.CFI = generatedContentDocCFI;            
+            annotationInfo.CFI = generatedContentDocCFI;
             return annotationInfo;
         }
         else {
@@ -753,7 +753,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             CFI = "epubcfi(" + arbitraryPackageDocCFI + generatedContentDocCFI + ")";
             annotationInfo = this.addBookmark(CFI, id, type);
 
-            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of 
+            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of
             //   the CFI variable in the current scope. Since this CFI variable contains a "hacked" CFI value -
             //   only the content document portion is valid - we want to replace the annotationInfo.CFI property with
             //   the partial content document CFI portion we originally generated.
@@ -788,7 +788,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             CFI = "epubcfi(" + arbitraryPackageDocCFI + generatedContentDocCFI + ")";
             annotationInfo = this.addImageAnnotation(CFI, id);
 
-            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of 
+            // Rationale: The annotationInfo object returned from .addBookmark(...) contains the same value of
             //   the CFI variable in the current scope. Since this CFI variable contains a "hacked" CFI value -
             //   only the content document portion is valid - we want to replace the annotationInfo.CFI property with
             //   the partial content document CFI portion we originally generated.
@@ -826,11 +826,11 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         }
 
         this.findSelectedElements(
-            selectedRange.commonAncestorContainer, 
-            selectedRange.startContainer, 
+            selectedRange.commonAncestorContainer,
+            selectedRange.startContainer,
             selectedRange.endContainer,
             intervalState,
-            selectedElements, 
+            selectedElements,
             elementType
         );
 
@@ -855,9 +855,9 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             endOffset = selectedRange.endOffset;
 
             rangeCFIComponent = this.epubCFI.generateCharOffsetRangeComponent(
-                startNode, 
-                startOffset, 
-                endNode, 
+                startNode,
+                startOffset,
+                endNode,
                 endOffset,
                 ["cfi-marker", "mo-cfi-highlight"],
                 [],
@@ -932,7 +932,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             }
             else {
                 if ($(currElement).is(elementType)) {
-                    selectedElements.push(currElement);    
+                    selectedElements.push(currElement);
                 }
             }
         });
@@ -1124,7 +1124,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         var bookmarkView = new EpubAnnotations.BookmarkView({
             CFI : CFI,
-            targetElement : targetElement, 
+            targetElement : targetElement,
             offsetTopAddition : offsetTop,
             offsetLeftAddition : offsetLeft,
             id : annotationId.toString(),
@@ -1154,8 +1154,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         delete annotationHash[annotationId];
 
-        highlights = _.reject(highlights, 
-                              function(obj) { 
+        highlights = _.reject(highlights,
+                              function(obj) {
                                   if (obj.id == annotationId) {
                                       obj.destroyCurrentHighlights();
                                       return true;
@@ -1185,7 +1185,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             selectedNodes : highlightedTextNodes,
             offsetTopAddition : offsetTop,
             offsetLeftAddition : offsetLeft,
-            styles: styles, 
+            styles: styles,
             id : annotationId,
             bbPageSetView : this.get("bbPageSetView"),
             scale: this.get("scale")
@@ -1246,7 +1246,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         return annotationViews;
     },
 
-    // REFACTORING CANDIDATE: Some kind of hash lookup would be more efficient here, might want to 
+    // REFACTORING CANDIDATE: Some kind of hash lookup would be more efficient here, might want to
     //   change the implementation of the annotations as an array
     validateAnnotationId : function (id) {
 
@@ -1270,7 +1270,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
         this.bookmark = new EpubAnnotations.Bookmark({
             CFI : options.CFI,
-            targetElement : options.targetElement, 
+            targetElement : options.targetElement,
             offsetTopAddition : options.offsetTopAddition,
             offsetLeftAddition : options.offsetLeftAddition,
             id : options.id,
@@ -1305,7 +1305,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         if (this.bookmark.get("type") === "comment") {
             absoluteTop = this.bookmark.getAbsoluteTop();
             absoluteLeft = this.bookmark.getAbsoluteLeft();
-            this.$el.css({ 
+            this.$el.css({
                 "top" : absoluteTop + "px",
                 "left" : absoluteLeft + "px",
                 "width" : "50px",
@@ -1348,9 +1348,9 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             type = "bookmark";
         }
 
-        this.bookmark.get("bbPageSetView").trigger("annotationClicked", 
-            type, 
-            this.bookmark.get("CFI"), 
+        this.bookmark.get("bbPageSetView").trigger("annotationClicked",
+            type,
+            this.bookmark.get("CFI"),
             this.bookmark.get("id"),
             this.$el.css("top"),
             this.$el.css("left"),
@@ -1412,8 +1412,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
     setCSS : function () {
 
         var styles = this.highlight.get("styles") || {};
-        
-        this.$el.css({ 
+
+        this.$el.css({
             "top" : this.highlight.get("top") + "px",
             "left" : this.highlight.get("left") + "px",
             "height" : this.highlight.get("height") + "px",
@@ -1500,8 +1500,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 
     setCSS : function () {
         var styles = this.underline.get("styles") || {};
-        
-        this.$el.css({ 
+
+        this.$el.css({
             "top" : this.underline.get("top") + "px",
             "left" : this.underline.get("left") + "px",
             "height" : this.underline.get("height") + "px",
@@ -1513,7 +1513,7 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
             "background-color" : styles.fill_color || "normal",
         });
 
-        
+
         this.$underlineElement.addClass("underline");
     },
 
@@ -1539,11 +1539,11 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
 });
 
     // Rationale: An image annotation does NOT have a view, as we don't know the state of an image element within an EPUB; it's entirely
-//   possible that an EPUB image element could have a backbone view associated with it already, which would cause problems if we 
+//   possible that an EPUB image element could have a backbone view associated with it already, which would cause problems if we
 //   tried to associate another backbone view. As such, this model modifies CSS properties for an annotated image element.
-//   
+//
 //   An image annotation view that manages an absolutely position element (similar to bookmarks, underlines and highlights) can be
-//   added if more functionality is required. 
+//   added if more functionality is required.
 
 EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
 
@@ -1569,11 +1569,10 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
     },
 
     setCSS : function () {
-        
+
         $(this.get("imageNode")).css({
             "border" : "5px solid rgb(255, 0, 0)",
             "border" : "5px solid rgba(255, 0, 0, 0.2)",
-            "-webkit-background-clip" : "padding-box",
             "background-clip" : "padding-box"
         });
     },
@@ -1596,7 +1595,7 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
 
 
     var reflowableAnnotations = new EpubAnnotations.ReflowableAnnotations({
-        contentDocumentDOM : contentDocumentDOM, 
+        contentDocumentDOM : contentDocumentDOM,
         bbPageSetView : bbPageSetView,
         annotationCSSUrl : annotationCSSUrl,
     });
@@ -1604,46 +1603,46 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
     // Description: The public interface
     return {
 
-        addSelectionHighlight : function (id, type, styles) { 
-            return reflowableAnnotations.addSelectionHighlight(id, type, styles); 
+        addSelectionHighlight : function (id, type, styles) {
+            return reflowableAnnotations.addSelectionHighlight(id, type, styles);
         },
-        addSelectionBookmark : function (id, type) { 
-            return reflowableAnnotations.addSelectionBookmark(id, type); 
+        addSelectionBookmark : function (id, type) {
+            return reflowableAnnotations.addSelectionBookmark(id, type);
         },
         addSelectionImageAnnotation : function (id) {
             return reflowableAnnotations.addSelectionImageAnnotation(id);
         },
-        addHighlight : function (CFI, id, type, styles) { 
-            return reflowableAnnotations.addHighlight(CFI, id, type, styles); 
+        addHighlight : function (CFI, id, type, styles) {
+            return reflowableAnnotations.addHighlight(CFI, id, type, styles);
         },
-        addBookmark : function (CFI, id, type) { 
+        addBookmark : function (CFI, id, type) {
             return reflowableAnnotations.addBookmark(CFI, id, type);
         },
-        addImageAnnotation : function (CFI, id) { 
-            return reflowableAnnotations.addImageAnnotation(CFI, id); 
+        addImageAnnotation : function (CFI, id) {
+            return reflowableAnnotations.addImageAnnotation(CFI, id);
         },
         updateAnnotationView : function (id, styles) {
             return reflowableAnnotations.updateAnnotationView(id, styles);
         },
-        redraw : function () { 
-            return reflowableAnnotations.redraw(); 
+        redraw : function () {
+            return reflowableAnnotations.redraw();
         },
-        getBookmark : function (id) { 
-            return reflowableAnnotations.annotations.getBookmark(id); 
+        getBookmark : function (id) {
+            return reflowableAnnotations.annotations.getBookmark(id);
         },
-        getBookmarks : function () { 
-            return reflowableAnnotations.annotations.getBookmarks(); 
-        }, 
-        getHighlight : function (id) { 
-            return reflowableAnnotations.annotations.getHighlight(id); 
+        getBookmarks : function () {
+            return reflowableAnnotations.annotations.getBookmarks();
         },
-        getHighlights : function () { 
-            return reflowableAnnotations.annotations.getHighlights(); 
+        getHighlight : function (id) {
+            return reflowableAnnotations.annotations.getHighlight(id);
         },
-        getUnderline : function (id) { 
-            return reflowableAnnotations.annotations.getUnderline(id); 
+        getHighlights : function () {
+            return reflowableAnnotations.annotations.getHighlights();
         },
-        getUnderlines : function () { 
+        getUnderline : function (id) {
+            return reflowableAnnotations.annotations.getUnderline(id);
+        },
+        getUnderlines : function () {
             return reflowableAnnotations.annotations.getUnderlines();
         },
         getImageAnnotation : function () {
@@ -1651,7 +1650,7 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
         },
         getImageAnnotations : function () {
 
-        }, 
+        },
         removeAnnotation: function (annotationId) {
             return reflowableAnnotations.remove(annotationId);
         },


### PR DESCRIPTION
jQuery (since 1.8) automagically adds vendor prefix to CSS rules when necessary, by detecting if the property exists on the style object of a DOM element.
- my editor removes trailing spaces
