### PR TITLE
jQuery automatically adds css prefix when necessary. No need to add them

### DIFF
--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -245,11 +245,10 @@ ReadiumSDK.Views.OnePageView = function(options, classes){
         var transformString = "translate(" + left + "px, " + top + "px) scale(" + scale + ")";
 
         //TODO modernizer library can be used to get browser independent transform attributes names (implemented in readium-web fixed_layout_book_zoomer.js)
-        var css = {};
-        css["-webkit-transform"] = transformString;
-        css["-webkit-transform-origin"] = "0 0";
-
-        return css;
+        return {
+            "transform": transformString,
+            "transform-origin": "0 0"
+        };
     }
 
     function updateMetaSize() {

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -180,8 +180,6 @@ ReadiumSDK.Views.ReflowableView = function(options){
     function updateColumnGap() {
 
         if(_$epubHtml) {
-            _$epubHtml.css("-webkit-column-gap", _paginationInfo.columnGap + "px");
-            _$epubHtml.css("-moz-column-gap", _paginationInfo.columnGap + "px");
             _$epubHtml.css("column-gap", _paginationInfo.columnGap + "px");
         }
     }
@@ -206,9 +204,11 @@ ReadiumSDK.Views.ReflowableView = function(options){
         var epubContentDocument = _$iframe[0].contentDocument;
         _$epubHtml = $("html", epubContentDocument);
 
-        _$epubHtml.css("height", _lastViewPortSize.height + "px");
-        _$epubHtml.css("position", "relative");
-        _$epubHtml.css("-webkit-column-axis", "horizontal");
+        _$epubHtml.css({
+            height: _lastViewPortSize.height + "px",
+            position: "relative",
+            "column-axis": "horizontal"
+        });
 
         self.applyBookStyles();
         resizeImages();
@@ -418,8 +418,6 @@ ReadiumSDK.Views.ReflowableView = function(options){
 
         hideBook(); // shiftBookOfScreen();
 
-        _$epubHtml.css("-webkit-column-width", _paginationInfo.columnWidth + "px");
-        _$epubHtml.css("-moz-column-width", _paginationInfo.columnWidth + "px");
         _$epubHtml.css("column-width", _paginationInfo.columnWidth + "px");
 
         //TODO it takes time for rendition_layout engine to arrange columns we waite

--- a/lib/annotations_module.js
+++ b/lib/annotations_module.js
@@ -1573,7 +1573,6 @@ EpubAnnotations.ImageAnnotation = Backbone.Model.extend({
         $(this.get("imageNode")).css({
             "border" : "5px solid rgb(255, 0, 0)",
             "border" : "5px solid rgba(255, 0, 0, 0.2)",
-            "-webkit-background-clip" : "padding-box",
             "background-clip" : "padding-box"
         });
     },


### PR DESCRIPTION
In this branch, almost everything is already browser-agnostic in terms of CSS rules. This pull request goes one small step further in that direction.
