### PR TITLE
Fixes bug 76 where fixed page background was incorrectly scaled. (take 2)

### DIFF
--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -513,8 +513,8 @@ ReadiumSDK.Views.OnePageView = function(options, classes, enableBookStyleOverrid
         _$el.css("width", elWidth + "px");
         _$el.css("height", elHeight + "px");
 
-        _$iframe.css("width", elWidth + "px");
-        _$iframe.css("height", elHeight + "px");
+        _$iframe.css("width", _meta_size.width + "px");
+        _$iframe.css("height", _meta_size.height + "px");
 
         if(!_$epubHtml) {
 //            debugger;


### PR DESCRIPTION
Modified to set the width and height of the iframe to the
original size rather than the viewed size.

This fixes the specific case in bug76 with a one page view that has a background image that gets scaled incorrectly. I tested with other files and this does not seem to adversely affect other rendering. I suspect that is because the outer div of the iframe as the desired width and height. I would be happy to test more with guidance from folks that may understand the implications of this change better than me.
