### PR TITLE
Made removeHighlight work in IE. elem.remove() was experimental DOM API

### DIFF
--- a/lib/annotations_module.js
+++ b/lib/annotations_module.js
@@ -1147,8 +1147,8 @@ var EpubAnnotationsModule = function (contentDocumentDOM, bbPageSetView, annotat
         var startMarker =  markers[annotationId].startMarker;
         var endMarker = markers[annotationId].endMarker;
 
-        startMarker.remove();
-        endMarker.remove();
+        startMarker.parentNode.removeChild(startMarker);
+        endMarker.parentNode.removeChild(endMarker);
 
         delete markers[annotationId];
 


### PR DESCRIPTION
node.remove() is experimental and not supported by Internet Explorer. See https://developer.mozilla.org/en-US/docs/Web/API/ChildNode.remove#Browser_compatibility

The fixed code works in all browsers.
