### PR TITLE
Added missing getElementByCfi() to ReadiumSDK.Views.ScrollView

### DIFF
--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -1107,6 +1107,29 @@ ReadiumSDK.Views.ScrollView = function(options, isContinuousScroll){
 
         return element;
     };
+
+    this.getElementByCfi = function(spineItem, cfi, classBlacklist, elementBlacklist, idBlacklist) {
+
+        var found = undefined;
+
+        forEachItemView(function (pageView) {
+            if(pageView.currentSpineItem() == spineItem) {
+
+                found = pageView.getElementByCfi(spineItem, cfi, classBlacklist, elementBlacklist, idBlacklist);
+                return false;
+            }
+
+            return true;
+
+        }, false);
+
+        if(!found) {
+            console.error("spine item is not loaded");
+            return undefined;
+        }
+
+        return found;
+    };
     
     this.getElementById = function(spineItem, id) {
         


### PR DESCRIPTION
For some reasons the getElementByCfi() function is missing in ScrollView. This breaks our code when using ReadiumSDK.Views.ReaderView.getElementByCfi and the current view is a ScrollView. I'm not sure why the function is missing, but this commit does seem to do the trick. Alternatively, ReadiumSDK.Views.ReaderView.getElementByCfi should check if _currentView implements this function. Any opinions?
