### PR TITLE
Introducing media overlay highlighter events

### DIFF
--- a/js/readium_sdk.js
+++ b/js/readium_sdk.js
@@ -65,7 +65,9 @@ ReadiumSDK = {
                 CONTENT_DOCUMENT_LOADED: "ContentDocumentLoaded",
                 MEDIA_OVERLAY_STATUS_CHANGED: "MediaOverlayStatusChanged",
                 MEDIA_OVERLAY_TTS_SPEAK: "MediaOverlayTTSSpeak",
-                MEDIA_OVERLAY_TTS_STOP: "MediaOverlayTTSStop"
+                MEDIA_OVERLAY_TTS_STOP: "MediaOverlayTTSStop",
+                MEDIA_OVERLAY_HIGHLIGHT_APPLIED: "MediaOverlayHighlightApplied",
+                MEDIA_OVERLAY_HIGHLIGHT_REMOVED: "MediaOverlayHighlightRemoved"
             },
 
     InternalEvents: {

--- a/js/views/media_overlay_element_highlighter.js
+++ b/js/views/media_overlay_element_highlighter.js
@@ -208,7 +208,8 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
         {
             $(_highlightedElementPar.element).addClass(DEFAULT_MO_SUB_SYNC_CLASS);
         }
-        
+
+        _reader.trigger(ReadiumSDK.Events.MEDIA_OVERLAY_HIGHLIGHT_APPLIED, element);
 // ---- CFI
 //         try
 //         {
@@ -482,6 +483,7 @@ ReadiumSDK.Views.MediaOverlayElementHighlighter = function(reader) {
             //}
 
             _highlightedElementPar = undefined;
+            _reader.trigger(ReadiumSDK.Events.MEDIA_OVERLAY_HIGHLIGHT_REMOVED, element);
         }
 
         _activeClass = "";


### PR DESCRIPTION
Adding events for media overlay highligher. Those are necessary in case one wants to follow the (de-)highlighted elements with some applications' graphical elements (fade-out effects, adjustable audio button etc.)
Note that the events currently are triggered only by 'highlightElement' logic (w/o CFI). That's intentional, as with CFI we basically won't have an element in DOM when highlight is removed.
