### PR TITLE
Add the footnotes plugin and plugins controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Session.vim
 .netrwhist
 *~
+.DS_Store

--- a/js/controllers/plugins.js
+++ b/js/controllers/plugins.js
@@ -1,0 +1,98 @@
+//
+//  Created by Mickaël Menu.
+//  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification, 
+//  are permitted provided that the following conditions are met:
+//  1. Redistributions of source code must retain the above copyright notice, this 
+//  list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, 
+//  this list of conditions and the following disclaimer in the documentation and/or 
+//  other materials provided with the distribution.
+//  3. Neither the name of the organization nor the names of its contributors may be 
+//  used to endorse or promote products derived from this software without specific 
+//  prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//  OF THE POSSIBILITY OF SUCH DAMAGE.
+
+//
+// A lightweight plugins controller used to easily add plugins from the host
+// app, eg.
+//
+//   ReadiumSDK.plugins.load(FootnotePlugin, true);
+//
+// The controller will create a new instance of the plugin, forwarding any given
+// arguments. Then, on several useful common Readium notifications, the
+// controller will call predefined callbacks if implemented in the plug-in.
+//
+// Supported callbacks are:
+//      onReaderInitialized()
+//      onDocumentLoadStart($iframe, spineItem)
+//      onDocumentLoadedBeforeInjection($iframe, $document, spineItem);
+//      onDocumentLoaded($iframe, $document, spineItem);
+//
+
+function PluginsController() {
+    this.plugins = [];
+
+    var self = this;
+
+    ReadiumSDK.on(ReadiumSDK.Events.READER_INITIALIZED, function(reader) {
+        var reader = ReadiumSDK.reader;
+
+        self.notifyPlugins("onReaderInitialized", reader);
+
+        reader.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOAD_START, function($iframe, spineItem) {
+            var $document = $($iframe[0].contentDocument);
+            self.notifyPlugins("onDocumentLoadStart", $iframe, spineItem)
+        });
+
+        reader.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED_BEFORE_INJECTION, function($iframe, spineItem) {
+            var $document = $($iframe[0].contentDocument);
+            self.notifyPlugins("onDocumentLoadedBeforeInjection", $iframe, $document, spineItem)
+        });
+
+        reader.on(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, function($iframe, spineItem) {
+            var $document = $($iframe[0].contentDocument);
+            self.notifyPlugins("onDocumentLoaded", $iframe, $document, spineItem);
+        });
+    });
+};
+
+// Creates a new instance of the given plugin constructor.
+PluginsController.prototype.load = function(pluginType) {
+    var args = $.makeArray(arguments);
+    args.shift();
+    function F() {
+        return pluginType.apply(this, args);
+    }
+    F.prototype = constructor.prototype;
+
+    var plugin = new F(args);
+    this.plugins.push(plugin);
+};
+
+// Calls the method <name> on any plugin that implements it, forwarding any
+// given argument.
+PluginsController.prototype.notifyPlugins = function(name) {
+    var args = $.makeArray(arguments);
+    args.shift();
+
+    var self = this;
+    $(this.plugins).each(function(index, plugin) {
+        var callback = plugin[name];
+        if (callback)
+            callback.apply(plugin, args);
+    });
+};
+
+ReadiumSDK.plugins = new PluginsController();

--- a/js/plugins/footnotes.js
+++ b/js/plugins/footnotes.js
@@ -1,0 +1,75 @@
+//
+//  Created by Mickaël Menu.
+//  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification, 
+//  are permitted provided that the following conditions are met:
+//  1. Redistributions of source code must retain the above copyright notice, this 
+//  list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, 
+//  this list of conditions and the following disclaimer in the documentation and/or 
+//  other materials provided with the distribution.
+//  3. Neither the name of the organization nor the names of its contributors may be 
+//  used to endorse or promote products derived from this software without specific 
+//  prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//  OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// A plugin used to notify the host app when an EPUB 3 footnote is clicked.
+//
+// When the user activate a footnote, the FootnoteClicked notification is sent
+// to the host app with the following argument:
+// {
+//    x: x position of the click,
+//    y: y position of the click,
+//    title: title of the link of the footnote,
+//    content: HTML content of the footnote
+// }
+//
+// When loading the plugin, you can specify as an argument whether you want to
+// hides the original footnote nodes in the document.
+//
+
+ReadiumSDK.Events.FOOTNOTE_CLICKED = "FootnoteClicked";
+
+function FootnotesPlugin(hideFootnotes) {
+    this.hideFootnotes = hideFootnotes;
+
+    var self = this;
+    this.onDocumentLoadedBeforeInjection = function($iframe, $document, spineItem) {
+        // adds behaviour for noteref
+        $document.
+            find("a[epub\\:type='noteref']").
+            on("click", function(event) {
+                var title = $(this).html();
+                var content = $document.find($(this).attr('href')).html();
+
+                ReadiumSDK.reader.trigger(ReadiumSDK.Events.FOOTNOTE_CLICKED, {
+                    x: event.pageX,
+                    y: event.pageY,
+                    title: title,
+                    content: content
+                });
+                
+                // we stop immediate propagation to avoid Readium to move the reader
+                // to the internal location of the footnote
+                event.stopImmediatePropagation();
+                return false;
+            });
+
+        // hides footnotes if needed
+        if (self.hideFootnotes) {
+            $document.find("aside[epub\\:type='footnote']").hide();
+            $document.find("aside[epub\\:type='note']").hide();
+        }
+    };
+}

--- a/js/readium_sdk.js
+++ b/js/readium_sdk.js
@@ -62,6 +62,10 @@ ReadiumSDK = {
                 READER_VIEW_CREATED: "ReaderViewCreated",
                 READER_VIEW_DESTROYED: "ReaderViewDestroyed",
                 CONTENT_DOCUMENT_LOAD_START: "ContentDocumentLoadStart",
+                // Triggered when the content document is loaded but before
+                // injecting Readium listeners into the page. Use this to
+                // override default listeners.
+                CONTENT_DOCUMENT_LOADED_BEFORE_INJECTION: "ContentDocumentLoadedBeforeInjection",
                 CONTENT_DOCUMENT_LOADED: "ContentDocumentLoaded",
                 MEDIA_OVERLAY_STATUS_CHANGED: "MediaOverlayStatusChanged",
                 MEDIA_OVERLAY_TTS_SPEAK: "MediaOverlayTTSSpeak",

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -177,6 +177,8 @@ ReadiumSDK.Views.ReaderView = function(options) {
 
             if (!ReadiumSDK.Helpers.isIframeAlive($iframe[0])) return;
 
+            self.trigger(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED_BEFORE_INJECTION, $iframe, spineItem);
+
             // performance degrades with large DOM (e.g. word-level text-audio sync)
             _mediaOverlayDataInjector.attachMediaOverlayData($iframe, spineItem, _viewerSettings);
             


### PR DESCRIPTION
The plugins controller is really lightweight and just to have an easy way to opt-out of a plugin from the host implementers and to listen more easily to common Readium notifications.