### PR TITLE
#115: Reflowable page in FXL document is not laid out properly when in two-up mode

### DIFF
--- a/js/models/fixed_page_spread.js
+++ b/js/models/fixed_page_spread.js
@@ -82,7 +82,10 @@ ReadiumSDK.Models.Spread = function(spine, isSyntheticSpread) {
             var neighbour = getNeighbourItem(item);
             if(neighbour) {
                 var neighbourPos = getItemPosition(neighbour);
-                if(neighbourPos != position && neighbourPos != ReadiumSDK.Models.Spread.POSITION_CENTER)  {
+                if (neighbourPos != position
+                    && neighbourPos != ReadiumSDK.Models.Spread.POSITION_CENTER
+                    //exclude a neighbour that is a reflowable item from the spread (see RSJ#115)
+                    && !neighbour.isReflowable()) {
                     setItemToPosition(neighbour, neighbourPos);
                 }
             }


### PR DESCRIPTION
This simply excludes a reflowable spine item from appearing along side a neighbour in a fixed-layout spread.
The reflowable spine item gets its own exclusive spread in the next pagination.
