### PR TITLE
spine item rendition:spread-none correctly handled in synthetic spread

### DIFF
--- a/js/models/fixed_page_spread.js
+++ b/js/models/fixed_page_spread.js
@@ -78,14 +78,14 @@ ReadiumSDK.Models.Spread = function(spine, isSyntheticSpread) {
         var position = getItemPosition(item);
         setItemToPosition(item, position);
 
-        if(position != ReadiumSDK.Models.Spread.POSITION_CENTER) {
+        if(position != ReadiumSDK.Models.Spread.POSITION_CENTER && this.spine.isValidLinearItem(item.index)) { // && item.isRenditionSpreadAllowed() not necessary, see getItemPosition() below
             var neighbour = getNeighbourItem(item);
             if(neighbour) {
                 var neighbourPos = getItemPosition(neighbour);
-                if (neighbourPos != position
+                if(neighbourPos != position
                     && neighbourPos != ReadiumSDK.Models.Spread.POSITION_CENTER
-                    //exclude a neighbour that is a reflowable item from the spread (see RSJ#115)
-                    && !neighbour.isReflowable()) {
+                    && !neighbour.isReflowable()
+                    && neighbour.isRenditionSpreadAllowed())  {
                     setItemToPosition(neighbour, neighbourPos);
                 }
             }
@@ -118,7 +118,8 @@ ReadiumSDK.Models.Spread = function(spine, isSyntheticSpread) {
     }
 
     function getItemPosition(item) {
-
+        
+        // includes !item.isRenditionSpreadAllowed() ("rendition:spread-none") ==> force center position
         if(!_isSyntheticSpread) {
             return ReadiumSDK.Models.Spread.POSITION_CENTER;
         }

--- a/js/models/spine.js
+++ b/js/models/spine.js
@@ -66,6 +66,11 @@ ReadiumSDK.Models.Spine = function(epubPackage, spineDTO) {
 
 
     this.isValidLinearItem = function(index) {
+        
+        if(!isValidIndex(index)) {
+            return undefined;
+        }
+
         return isValidLinearItem(this.item(index));
     };
 
@@ -198,7 +203,7 @@ ReadiumSDK.Models.Spine = function(epubPackage, spineDTO) {
             var spineItem = self.items[i];
             if( !spineItem.page_spread) {
 
-                var spread = isFirstPageInSpread ? baseSide : ReadiumSDK.Models.SpineItem.alternateSpread(baseSide);
+                var spread = spineItem.isRenditionSpreadAllowed() ? (isFirstPageInSpread ? baseSide : ReadiumSDK.Models.SpineItem.alternateSpread(baseSide)) : ReadiumSDK.Models.SpineItem.SPREAD_CENTER;
                 spineItem.setSpread(spread);
             }
 


### PR DESCRIPTION
Fixes: https://github.com/readium/readium-shared-js/issues/128
