### PR TITLE
review and clean-up of the CSS 3D GPU-accelerated code routines (now off by default)

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -336,7 +336,10 @@ ReadiumSDK.Helpers.loadTemplate = function(name, params) {
 
 ReadiumSDK.Helpers.loadTemplate.cache = {
     "fixed_book_frame" : '<div id="fixed-book-frame" class="clearfix book-frame fixed-book-frame"></div>',
+    
     "single_page_frame" : '<div><div id="scaler"><iframe scrolling="no" class="iframe-fixed"></iframe></div></div>',
+    //"single_page_frame" : '<div><iframe scrolling="no" class="iframe-fixed" id="scaler"></iframe></div>',
+    
     "scrolled_book_frame" : '<div id="reflowable-book-frame" class="clearfix book-frame reflowable-book-frame"><div id="scrolled-content-frame"></div></div>',
     "reflowable_book_frame" : '<div id="reflowable-book-frame" class="clearfix book-frame reflowable-book-frame"></div>',
     "reflowable_book_page_frame": '<div id="reflowable-content-frame" class="reflowable-content-frame"><iframe scrolling="no" id="epubContentIframe"></iframe></div>'
@@ -408,6 +411,8 @@ ReadiumSDK.Helpers.isRenditionSpreadPermittedForItem = function(item, orientatio
 
 //scale, left, top, angle, origin
 ReadiumSDK.Helpers.CSSTransformString = function(options) {
+    var enable3D = options.enable3D ? true : false;
+    
     var translate, scale, rotation,
         origin = options.origin;
 
@@ -415,13 +420,13 @@ ReadiumSDK.Helpers.CSSTransformString = function(options) {
         var left = options.left || 0, 
             top = options.top || 0;
 
-        translate = "translate(" + left + "px, " + top + "px)";
+        translate = enable3D ? ("translate3D(" + left + "px, " + top + "px, 0)") : ("translate(" + left + "px, " + top + "px)");
     }
     if (options.scale){
-        scale = "scale(" + options.scale + ")";
+        scale = enable3D ? ("scale3D(" + options.scale + ", " + options.scale + ", 0)") : ("scale(" + options.scale + ")");
     }
     if (options.angle){
-        rotation =  "rotate(" + options.angle + "deg)";
+        rotation =  enable3D ? ("rotate3D(0,0," + options.angle + "deg)") : ("rotate(" + options.angle + "deg)");
     }
     
     if (!(translate || scale || rotation)){
@@ -439,7 +444,7 @@ ReadiumSDK.Helpers.CSSTransformString = function(options) {
     var css = {};
     _.each(['-webkit-', '-moz-', '-ms-', ''], function(prefix) {
         css[prefix + 'transform'] = transformString;
-        css[prefix + 'transform-origin'] = origin ? origin : '0 0';
+        css[prefix + 'transform-origin'] = origin ? origin : (enable3D ? '0 0 0' : '0 0');
     });
 
     return css;

--- a/js/models/viewer_settings.js
+++ b/js/models/viewer_settings.js
@@ -48,7 +48,7 @@ ReadiumSDK.Models.ViewerSettings = function(settingsData) {
 
     this.mediaOverlaysAutomaticPageTurn = true;
 
-    this.enableGPUHardwareAccelerationCSS3D = true;
+    this.enableGPUHardwareAccelerationCSS3D = false;
 
     // -1 ==> disable
     // [0...n] ==> index of transition in pre-defined array

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -95,6 +95,19 @@ ReadiumSDK.Views.FixedView = function(options, reader){
         
         _$el.css("overflow", "hidden");
         
+        // Removed, see one_page_view@render()
+        // var settings = _viewSettings;
+        // if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
+        // {
+        //     //defaults
+        //     settings = new ReadiumSDK.Models.ViewerSettings({});
+        // }
+        // if (settings.enableGPUHardwareAccelerationCSS3D) {
+        //
+        //     // This fixes rendering issues with WebView (native apps), which crops content embedded in iframes unless GPU hardware acceleration is enabled for CSS rendering.
+        //     _$el.css("transform", "translateZ(0)");
+        // }
+        
         _$viewport.append(_$el);
 
         self.applyStyles();
@@ -221,7 +234,7 @@ ReadiumSDK.Views.FixedView = function(options, reader){
 
         updateContentMetaSize();
         resizeBook();
-
+        
         self.trigger(ReadiumSDK.InternalEvents.CURRENT_VIEW_PAGINATION_CHANGED, { paginationInfo: self.getPaginationInfo(), initiator: initiator, spineItem: paginationRequest_spineItem, elementId: paginationRequest_elementId } );
     }
 
@@ -314,6 +327,7 @@ ReadiumSDK.Views.FixedView = function(options, reader){
         else{
             scale = Math.min(horScale, verScale);
         }
+
         _currentScale = scale;
 
         var contentSize = { width: _contentMetaSize.width * scale,
@@ -362,6 +376,7 @@ ReadiumSDK.Views.FixedView = function(options, reader){
 
             _centerPageView[transFunc](scale, left, top);
         }
+        
         self.trigger(ReadiumSDK.Events.FXL_VIEW_RESIZED);
     }
 


### PR DESCRIPTION
This is a follow-up to:
https://github.com/readium/SDKLauncher-OSX/issues/16
https://github.com/readium/readium-shared-js/pull/132

GPU-accelerated CSS rendering was creating too many nasty side effects (whilst only fixing one particular type of bug), and the native WebView can be configured so that surface compositing works well with the iframes inside reader.html.
