### PR TITLE
Added prefixed css-rules when resetting transform on showIFrame

### DIFF
--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -473,12 +473,15 @@ ReadiumSDK.Views.OnePageView = function(options, classes, enableBookStyleOverrid
     var _useCSSTransformToHideIframe = true;
 
     this.showIFrame = function() {
-
+        var css = {};
         _$iframe.css("visibility", "visible");
         
         if (_useCSSTransformToHideIframe)
         {
-            _$iframe.css("transform", "none");
+            _.each([ "", "-webkit-", "-moz-", "-ms-" ], function(prefix) {
+                css[prefix + "transform"] = "none";
+            });
+            _$iframe.css(css);
 
             var enable3D = false;
             var settings = _viewSettings;
@@ -490,7 +493,10 @@ ReadiumSDK.Views.OnePageView = function(options, classes, enableBookStyleOverrid
             if (settings.enableGPUHardwareAccelerationCSS3D)
             {
                 enable3D = true;
-                _$iframe.css("transform", "translateZ(0)");
+                _.each([ "", "-webkit-", "-moz-", "-ms-" ], function(prefix) {
+                    css[prefix + "transform"] = "translateZ(0)";
+                });
+                _$iframe.css(css);
             }
         }
         else


### PR DESCRIPTION
CSS vendor prefixes were added in hideIFrame (via ReadiumSDK.Helpers.CSSTransformString), but not removed in showIFrame.
This resulted in the iframe remaining 'invisible' even after showIframe.
