### PR TITLE
Firefox occasionally leaves opacity at 0

### DIFF
--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -697,7 +697,7 @@ ReadiumSDK.Views.ReflowableView = function(options, reader){
     {
         if (_currentOpacity != -1)
         {
-            _$epubHtml.css('opacity', _currentOpacity);
+            _$epubHtml.css('opacity', "1");
         }
         _currentOpacity = -1;
     }

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -61,8 +61,6 @@ ReadiumSDK.Views.ReflowableView = function(options, reader){
     var _htmlBodyIsLTRWritingMode;
     
     
-    var _currentOpacity = -1;
-
     var _lastViewPortSize = {
         width: undefined,
         height: undefined
@@ -687,19 +685,12 @@ ReadiumSDK.Views.ReflowableView = function(options, reader){
 
     function hideBook()
     {
-        if (_currentOpacity != -1) return; // already hidden
-        
-        _currentOpacity = _$epubHtml.css('opacity');
         _$epubHtml.css('opacity', "0");
     }
 
     function showBook()
     {
-        if (_currentOpacity != -1)
-        {
-            _$epubHtml.css('opacity', "1");
-        }
-        _currentOpacity = -1;
+        _$epubHtml.css('opacity', "1");
     }
 
     this.getFirstVisibleElementCfi = function() {


### PR DESCRIPTION
I found that in Firefox, changing to / from single column or changing font sizes could cause the epub contents to not be drawn. It was caused by hideBook and showBook being called rapidly in succession. It appears to be a race condition in Firefox where the css value from the last call to showBook hasn't yet applied when hideBook gets called next which caused both the css value for opacity and _currentOpacity to be set to 0. From then on subsequent calls to showBook and hideBook just kept reading and using the 0 value.