### PR TITLE
Redraw highlight divs when the viewport is resized

### DIFF
--- a/js/views/annotations_manager.js
+++ b/js/views/annotations_manager.js
@@ -211,6 +211,12 @@ ReadiumSDK.Views.AnnotationsManager = function (proxyObj, options) {
         return result;
     };
 
+    this.redrawHighlights = function() {
+        for(var spine in liveAnnotations) {
+            var annotationsForView = liveAnnotations[spine];
+            annotationsForView.redraw();
+        }
+    };
 
 
     function getPartialCfi(CFI) {

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -1172,6 +1172,7 @@ ReadiumSDK.Views.ReaderView = function(options) {
         else
         {
             _currentView.onViewportResize();
+            _annotationsManager.redrawHighlights();
         }
     };
 


### PR DESCRIPTION
When the viewport of the cloud reader is resized, the highlights show up at apparently random locations. This is because the absolutely positioned highlight-divs are not repositioned when the window is resized.

Digging into the annotation module in Readium I saw that the code for redrawing the highlight divs is available in the redraw()-method, it's just never called. This patch solves the problem in the cloud reader, but I'm not sure if calling redrawHighlights from js/views/reader_view.js:handleViewportResize() is enough.

Any help would be appreciated!

Jan