### PR TITLE
Prefetching (WIP)

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -352,6 +352,10 @@ Helpers.deduceSyntheticSpread = function ($viewport, spineItem, settings) {
 
     //http://www.idpf.org/epub/fxl/#property-spread-values
 
+    if (settings === undefined) {
+        return false;
+    }
+
     var rendition_spread = spineItem ? spineItem.getRenditionSpread() : undefined;
 
     if (rendition_spread === SpineItem.RENDITION_SPREAD_NONE) {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -434,26 +434,28 @@ Helpers.Margins.empty = function () {
  *
  * @param name
  * @param params
- * @returns {Helpers.loadTemplate.cache}
+ * @returns {Helpers.loadTemplate}
  */
-Helpers.loadTemplate = function (name, params) {
-    return Helpers.loadTemplate.cache[name];
+Helpers.loadTemplate = function(name, params) {
+    var uniqueIframeId = _.uniqueId("-uid-");
+   /**
+     *
+     * @type {{fixed_book_frame: string, single_page_frame: string, scrolled_book_frame: string, reflowable_book_frame: string, reflowable_book_page_frame: string}}
+     */
+    var template =  {
+        "fixed_book_frame" : '<div id="fixed-book-frame' + uniqueIframeId + '" class="clearfix book-frame fixed-book-frame"></div>',
+        
+        "single_page_frame" : '<div><div id="scaler"><iframe scrolling="no" class="iframe-fixed"></iframe></div></div>',
+        //"single_page_frame" : '<div><iframe scrolling="no" class="iframe-fixed" id="scaler"></iframe></div>',
+        
+        "scrolled_book_frame" : '<div id="reflowable-book-frame' + uniqueIframeId + '" class="clearfix book-frame reflowable-book-frame"><div id="scrolled-content-frame"></div></div>',
+        "reflowable_book_frame" : '<div id="reflowable-book-frame' + uniqueIframeId + '" class="clearfix book-frame reflowable-book-frame"></div>',
+        "reflowable_book_page_frame": '<div id="reflowable-content-frame" class="reflowable-content-frame"><iframe scrolling="no" id="epubContentIframe"></iframe></div>'
+    };
+    return template[name];
 };
 
-/**
- *
- * @type {{fixed_book_frame: string, single_page_frame: string, scrolled_book_frame: string, reflowable_book_frame: string, reflowable_book_page_frame: string}}
- */
-Helpers.loadTemplate.cache = {
-    "fixed_book_frame": '<div id="fixed-book-frame" class="clearfix book-frame fixed-book-frame"></div>',
 
-    "single_page_frame": '<div><div id="scaler"><iframe scrolling="no" class="iframe-fixed"></iframe></div></div>',
-    //"single_page_frame" : '<div><iframe scrolling="no" class="iframe-fixed" id="scaler"></iframe></div>',
-
-    "scrolled_book_frame": '<div id="reflowable-book-frame" class="clearfix book-frame reflowable-book-frame"><div id="scrolled-content-frame"></div></div>',
-    "reflowable_book_frame": '<div id="reflowable-book-frame" class="clearfix book-frame reflowable-book-frame"></div>',
-    "reflowable_book_page_frame": '<div id="reflowable-content-frame" class="reflowable-content-frame"><iframe scrolling="no" id="epubContentIframe"></iframe></div>'
-};
 
 /**
  *

--- a/js/models/cache_manager.js
+++ b/js/models/cache_manager.js
@@ -1,0 +1,84 @@
+/**
+ * @class 
+ */
+ReadiumSDK.Models.CacheManager = function() {
+    var self = this;
+
+    var _cachedViews = [];
+
+    var _iframeRereferences = [];
+
+
+
+    //////////////////
+    // private helpers
+
+    // we need to find whether we've already cached a particular spine item. 
+    // lets ask all of the existing views for the spine items that they are 
+    // holding (remember, each view may hold more than one)
+    function getCachedViewForSpineItem(spineItem) {
+        return _.find(_cachedViews, function(view){
+            var loadedspines = view.getLoadedSpineItems();
+            var foundView = _.find(loadedspines, function(spine) {
+                 return spine.index === spineItem.index;
+            });
+            return foundView;
+        });
+    };
+
+
+    function expireCachedItems(currentSpineItem) {
+        var currentSpineItemIndex = currentSpineItem.index;
+        // get all views that have an spine index more than 3 removed. it's simplistic but should work
+        // for both single and double fixed page layouts..
+        var cachedViewsToRemove = _.filter(_cachedViews, function(cachedView){
+            var spineItemForCachedView = cachedView.getLoadedSpineItems()[0];
+            return (Math.abs(spineItemForCachedView.index - currentSpineItemIndex) > 3); 
+        });
+
+        console.log("Pruning cached views, removing %d from the cached views list.", cachedViewsToRemove.length);
+
+        // remove views from the dom.
+        _.each(cachedViewsToRemove, function(viewToRemove) {
+            viewToRemove.remove();
+        });
+
+        // remove cached views from our local table.
+        _cachedViews = _.difference(_cachedViews, cachedViewsToRemove);
+    };
+
+
+    // TODODM: this needs to take spine item as a parameter, not an index. maybe.
+    function createPrefetchedViewForSpineItemIndex(spineItemIndex, setToPage) {
+        var spineItem = _spine.items[spineItemIndex];
+        var cachedView = getCachedViewForSpineItem(spineItem);
+        if (cachedView === undefined) {
+            var desiredViewType = deduceDesiredViewType(spineItem);
+
+            var viewCreationParams = {
+                $viewport: _$el,
+                spine: _spine,
+                userStyles: _userStyles,
+                bookStyles: _bookStyles,
+                iframeLoader: _iframeLoader,
+                cachedView: true
+            };
+
+            cachedView = self.createViewForType(desiredViewType, viewCreationParams);
+            var openPageRequest = new ReadiumSDK.Models.PageOpenRequest(spineItem, self);
+            if (setToPage === "last") {
+                openPageRequest.setLastPage();
+            } else {
+                openPageRequest.setFirstPage();
+            }
+
+            cachedView.render();
+            cachedView.setViewSettings(_viewerSettings);
+            cachedView.openPage(openPageRequest,2);
+            cachedView.setCached(true);
+            cachedView.hide();
+        }
+        return cachedView;
+    };
+
+};

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -68,6 +68,9 @@ var ViewManager = function(spine, reader) {
 
             callback(false, currentView); // view doesn't change!
         } else {
+            if (cachedView) {
+                self.destroyView(cachedView);
+            }
             currentView = createViewForItem(spineItem, viewCreationParams);
             saveViewOnceLoaded(currentView);
             currentView.render();
@@ -146,6 +149,12 @@ var ViewManager = function(spine, reader) {
 
         // remove cached views from our local table.
         _cachedViews = _.difference(_cachedViews, cachedViewsToRemove);
+    };
+
+    this.destroyView = function(cachedView) {
+        cachedView.remove();
+
+        _cachedViews = _.without(_cachedViews, cachedView);
     };
 
     // given a view returns it's type

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -29,7 +29,7 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
 
         var cachedView = self.getCachedViewForSpineItem(spineItem);
         self.cacheNeighboursForSpineItem(spineItem, currentView, viewCreationParams);
-        //self.expireCachedItems(spineItem);
+        self.expireCachedItems(spineItem);
 
         // there's a cached view, lets reset the _currentView then.
         if (cachedView !== undefined) {

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -264,7 +264,7 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
         // NOTE: _$el == options.$viewport
         //_$el.css("overflow", "hidden");
         options.$viewport.css("overflow", "hidden"); 
-        options.settings = _viewerSettings;
+        options.viewSettings = _viewerSettings;
         
         switch(viewType) {
             case ReadiumSDK.Views.ReaderView.VIEW_TYPE_FIXED:

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -10,6 +10,8 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
 
     var _iframeRereferences = {};
 
+    var _viewerSettings;
+
 
     ReadiumSDK.cacheStats = function () {
         console.log(_cachedViews);
@@ -17,6 +19,8 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
     };
 
     this.getViewForSpineItem = function(spineItem, currentView, viewerSettings, viewCreationParams, callback) {
+        _viewerSettings = viewerSettings;
+
         if (currentView) {
             currentView.hide();
             currentView.setCached(true);
@@ -39,7 +43,7 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
             currentView = createViewForItem(spineItem, viewCreationParams);
             saveViewOnceLoaded(currentView);
             currentView.render();
-            currentView.openPage(new ReadiumSDK.Models.PageOpenRequest(spineItem),1); 
+            currentView.openPage(new ReadiumSDK.Models.PageOpenRequest(spineItem),0); 
             currentView.once(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, function($iframe, spineItem) {
                 // proxy this event through to the reader
                 _.defer(function() {
@@ -260,6 +264,7 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
         // NOTE: _$el == options.$viewport
         //_$el.css("overflow", "hidden");
         options.$viewport.css("overflow", "hidden"); 
+        options.settings = _viewerSettings;
         
         switch(viewType) {
             case ReadiumSDK.Views.ReaderView.VIEW_TYPE_FIXED:

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -37,14 +37,12 @@ var ViewManager = function(spine, createViewForItem) {
 
     var _spine = spine;
 
-    var _iframeRereferences = {};
 
     var _viewerSettings;
 
     // debugging
     ReadiumSDK.cacheStats = function () {
         console.log(_cachedViews);
-        console.log(_iframeRereferences);
     };
 
 
@@ -68,7 +66,10 @@ var ViewManager = function(spine, createViewForItem) {
             cachedView.show();
             currentView = cachedView;
             currentView.setViewSettings(viewerSettings);
-            currentView.emit(Globals.Events.CONTENT_DOCUMENT_LOADED,_iframeRereferences[spineItem.index], spineItem);
+
+            currentView.onContentDocumentLoadStart(spineItem);
+            currentView.onContentDocumentLoaded(spineItem);
+
             callback(false, currentView); // view doesn't change!
         } else {
             currentView = createViewForItem(spineItem, viewCreationParams);
@@ -193,7 +194,6 @@ var ViewManager = function(spine, createViewForItem) {
             if (_.isUndefined(self.getCachedViewForSpineItem(spineItemForView))) {
                 console.log('%c View loaded in the background...%d cached views', 'background: grey; color: blue', _cachedViews.length);
                 _cachedViews.push(view);
-                _iframeRereferences[spineItem.index] = $iframe;
             }
         })
     };

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -12,12 +12,14 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
 
     var _viewerSettings;
 
-
+    // debugging
     ReadiumSDK.cacheStats = function () {
         console.log(_cachedViews);
         console.log(_iframeRereferences);
     };
 
+
+    // given a spine item and current view, will return a new or cached view for spine item and hide the "old" current view.
     this.getViewForSpineItem = function(spineItem, currentView, viewerSettings, viewCreationParams, callback) {
         _viewerSettings = viewerSettings;
 
@@ -74,12 +76,12 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
     };
 
 
+    // given a spine item, cache it's neigbhours. It's assumed that the spine item is currently visible on screen.
     this.cacheNeighboursForSpineItem = function(spineItem, currentView, viewCreationParams) {        
         // the next spine item to cache might be either +1 or +2. For a reflowable view it'll be +1,
         // for a synthetic spread it's going to be 2. In any case, this information is encapsulated 
         // in the number of currently loaded spines within the current view.
         var spinesWithinTheCurrentView = _.isUndefined(currentView)  ? 1 : currentView.getLoadedSpineItems().length; 
-
 
         // make a copy of the viewCreationParams so that we can apply the current settings to the cached views.
         var localViewCreationParams = _.extend({}, viewCreationParams);
@@ -99,6 +101,7 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
         }
     }
 
+    // given current spine item (the one that's on screen), prune cached items.
     this.expireCachedItems = function(currentSpineItem) {
         var currentSpineItemIndex = currentSpineItem.index;
         // get all views that have an spine index more than 3 removed. it's simplistic but should work
@@ -142,7 +145,7 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
 
 
 
-    // TODODM: this needs to take spine item as a parameter, not an index. maybe.
+    // create a cached view for a given spine item.
     function createPrefetchedViewForSpineItem(spineItem, setToPage, viewCreationParams) {
         var cachedView = self.getCachedViewForSpineItem(spineItem);
         if (cachedView === undefined) {

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -230,7 +230,7 @@ var ViewManager = function(spine, createViewForItem) {
             // cachedView.setViewSettings(_viewerSettings);
             cachedView.openPage(openPageRequest,direction);
             cachedView.setCached(true);
-            // cachedView.hide();
+            cachedView.hide();
         }
         return cachedView;
     };

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -122,6 +122,37 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
         _cachedViews = _.difference(_cachedViews, cachedViewsToRemove);
     };
 
+    // given a view returns it's type
+    this.viewTypeForView = function(view) {
+
+        if(!view) {
+            return undefined;
+        }
+
+        if(view instanceof ReadiumSDK.Views.ReflowableView) {
+            return ReadiumSDK.Views.ReaderView.VIEW_TYPE_COLUMNIZED;
+        }
+
+        if(view instanceof ReadiumSDK.Views.FixedView) {
+            return ReadiumSDK.Views.ReaderView.VIEW_TYPE_FIXED;
+        }
+
+        if(view instanceof ReadiumSDK.Views.ScrollView) {
+            if(view.isContinuousScroll()) {
+                return ReadiumSDK.Views.ReaderView.VIEW_TYPE_SCROLLED_CONTINUOUS;
+            }
+
+            return ReadiumSDK.Views.ReaderView.VIEW_TYPE_SCROLLED_DOC;
+        }
+
+        if(view instanceof ReadiumSDK.Views.FallbackScrollView) {
+            // fake a columnized view because it's a fallback of it
+            return ReadiumSDK.Views.ReaderView.VIEW_TYPE_COLUMNIZED;
+        }
+
+        console.error("Unrecognized view type");
+        return undefined;
+    };
 
     //////////////////
     // private helpers
@@ -218,41 +249,9 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
         var desiredViewType = deduceDesiredViewType(spineItem, viewCreationParams);
         console.assert(!_.isUndefined(viewCreationParams, "View creation params must be passed in!"));
 
-        view = self.createViewForType(desiredViewType, viewCreationParams);
+        view = createViewForType(desiredViewType, viewCreationParams);
         return view;
     }
-
-
-    this.viewTypeForView = function(view) {
-
-        if(!view) {
-            return undefined;
-        }
-
-        if(view instanceof ReadiumSDK.Views.ReflowableView) {
-            return ReadiumSDK.Views.ReaderView.VIEW_TYPE_COLUMNIZED;
-        }
-
-        if(view instanceof ReadiumSDK.Views.FixedView) {
-            return ReadiumSDK.Views.ReaderView.VIEW_TYPE_FIXED;
-        }
-
-        if(view instanceof ReadiumSDK.Views.ScrollView) {
-            if(view.isContinuousScroll()) {
-                return ReadiumSDK.Views.ReaderView.VIEW_TYPE_SCROLLED_CONTINUOUS;
-            }
-
-            return ReadiumSDK.Views.ReaderView.VIEW_TYPE_SCROLLED_DOC;
-        }
-
-        if(view instanceof ReadiumSDK.Views.FallbackScrollView) {
-            // fake a columnized view because it's a fallback of it
-            return ReadiumSDK.Views.ReaderView.VIEW_TYPE_COLUMNIZED;
-        }
-
-        console.error("Unrecognized view type");
-        return undefined;
-    };
 
 
        /**
@@ -261,7 +260,7 @@ ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
      * @param {ReadiumSDK.Views.ReaderView.ViewCreationOptions} options
      * @returns {*}
      */
-    this.createViewForType = function(viewType, options) {
+    function createViewForType(viewType, options) {
         var createdView;
 
         // NOTE: _$el == options.$viewport

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -24,8 +24,8 @@
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(["jquery", "underscore", "../globals", "./page_open_request", "../views/fixed_view",
-        "../views/scroll_view", "../views/reflowable_view", "../views/reader_view"],
-    function($, _, Globals, PageOpenRequest, FixedView, ScrollView, ReflowableView, ReaderView) {
+        "../views/scroll_view", "../views/reflowable_view"],
+    function($, _, Globals, PageOpenRequest, FixedView, ScrollView, ReflowableView) {
 
 /**
  * @class
@@ -159,19 +159,19 @@ var ViewManager = function(spine, createViewForItem) {
         }
 
         if (view instanceof ReflowableView) {
-            return ReaderView.VIEW_TYPE_COLUMNIZED;
+            return ViewManager.VIEW_TYPE_COLUMNIZED;
         }
 
         if (view instanceof FixedView) {
-            return ReaderView.VIEW_TYPE_FIXED;
+            return ViewManager.VIEW_TYPE_FIXED;
         }
 
         if (view instanceof ScrollView) {
             if (view.isContinuousScroll()) {
-                return ReaderView.VIEW_TYPE_SCROLLED_CONTINUOUS;
+                return ViewManager.VIEW_TYPE_SCROLLED_CONTINUOUS;
             }
 
-            return ReaderView.VIEW_TYPE_SCROLLED_DOC;
+            return ViewManager.VIEW_TYPE_SCROLLED_DOC;
         }
 
         console.error("Unrecognized view type");
@@ -240,29 +240,29 @@ var ViewManager = function(spine, createViewForItem) {
     function deduceDesiredViewType(spineItem, viewerSettings) {
         console.assert(!_.isUndefined(viewerSettings, "View creation params must be passed in!"));
         //check settings
-        if(viewerSettings.scroll == "scroll-doc") {
-            return ReaderView.VIEW_TYPE_SCROLLED_DOC;
+        if (viewerSettings.scroll == "scroll-doc") {
+            return ViewManager.VIEW_TYPE_SCROLLED_DOC;
         }
 
-        if(viewerSettings.scroll == "scroll-continuous") {
-            return ReaderView.VIEW_TYPE_SCROLLED_CONTINUOUS;
+        if (viewerSettings.scroll == "scroll-continuous") {
+            return ViewManager.VIEW_TYPE_SCROLLED_CONTINUOUS;
         }
 
         //is fixed layout ignore flow
-        if(spineItem.isFixedLayout()) {
-            return ReaderView.VIEW_TYPE_FIXED;
+        if (spineItem.isFixedLayout()) {
+            return ViewManager.VIEW_TYPE_FIXED;
         }
 
         //flow
-        if(spineItem.isFlowScrolledDoc()) {
-            return ReaderView.VIEW_TYPE_SCROLLED_DOC;
+        if (spineItem.isFlowScrolledDoc()) {
+            return ViewManager.VIEW_TYPE_SCROLLED_DOC;
         }
 
-        if(spineItem.isFlowScrolledContinuous()) {
-            return ReaderView.VIEW_TYPE_SCROLLED_CONTINUOUS;
+        if (spineItem.isFlowScrolledContinuous()) {
+            return ViewManager.VIEW_TYPE_SCROLLED_CONTINUOUS;
         }
 
-        return ReaderView.VIEW_TYPE_COLUMNIZED;
+        return ViewManager.VIEW_TYPE_COLUMNIZED;
     }
 
 
@@ -280,7 +280,7 @@ var ViewManager = function(spine, createViewForItem) {
 
        /**
      * Create a view based on the given view type.
-     * @param {ReaderView.ViewType} viewType
+     * @param {ViewManager.ViewType} viewType
      * @param {ReaderView.ViewCreationOptions} options
      * @returns {*}
      */
@@ -293,16 +293,16 @@ var ViewManager = function(spine, createViewForItem) {
         options.viewSettings = _viewerSettings;
 
         switch(viewType) {
-            case ReaderView.VIEW_TYPE_FIXED:
+            case ViewManager.VIEW_TYPE_FIXED:
 
                 options.$viewport.css("overflow", "auto"); // for content pan, see self.setZoom()
 
                 createdView = new FixedView(options, self);
                 break;
-            case ReaderView.VIEW_TYPE_SCROLLED_DOC:
+            case ViewManager.VIEW_TYPE_SCROLLED_DOC:
                 createdView = new ScrollView(options, false, self);
                 break;
-            case ReaderView.VIEW_TYPE_SCROLLED_CONTINUOUS:
+            case ViewManager.VIEW_TYPE_SCROLLED_CONTINUOUS:
                 createdView = new ScrollView(options, true, self);
                 break;
             default:
@@ -314,6 +314,19 @@ var ViewManager = function(spine, createViewForItem) {
     };
 
 };
+
+/**
+ * View Type
+ * @typedef {object} ViewManager.ViewType
+ * @property {number} VIEW_TYPE_COLUMNIZED          Reflowable document view
+ * @property {number} VIEW_TYPE_FIXED               Fixed layout document view
+ * @property {number} VIEW_TYPE_SCROLLED_DOC        Scrollable document view
+ * @property {number} VIEW_TYPE_SCROLLED_CONTINUOUS Continuous scrollable document view
+ */
+ViewManager.VIEW_TYPE_COLUMNIZED = 1;
+ViewManager.VIEW_TYPE_FIXED = 2;
+ViewManager.VIEW_TYPE_SCROLLED_DOC = 3;
+ViewManager.VIEW_TYPE_SCROLLED_CONTINUOUS = 4;
 
 return ViewManager;
 

--- a/js/models/view_manager.js
+++ b/js/models/view_manager.js
@@ -1,7 +1,7 @@
 /**
  * @class 
  */
-ReadiumSDK.Models.CacheManager = function(spine, createViewForItem) {
+ReadiumSDK.Models.ViewManager = function(spine, createViewForItem) {
     var self = this;
 
     var _cachedViews = [];

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -49,6 +49,8 @@ var FixedView = function(options, reader){
     var _iframeLoader = options.iframeLoader;
     var _viewSettings = undefined;
 
+    var _cached = options.cachedView || false;
+
     var _leftPageView = createOnePageView("fixed-page-frame-left");
     var _rightPageView = createOnePageView("fixed-page-frame-right");
     var _centerPageView = createOnePageView("fixed-page-frame-center");
@@ -69,7 +71,8 @@ var FixedView = function(options, reader){
         var pageView = new OnePageView(options,
         [elementClass],
         false, //enableBookStyleOverrides
-        reader
+        reader,
+        _cached
         );
 
         pageView.on(OnePageView.SPINE_ITEM_OPEN_START, function($iframe, spineItem) {
@@ -671,6 +674,34 @@ var FixedView = function(options, reader){
         //TODO: during zoom+pan, playing element might not actualy be visible
 
     }
+
+    this.getLoadedContentFrames = function () {
+        // TODODM this needs to be fixed properly. Most likely, the cacheman needs to track what spines are attached to what views?
+        try {
+            return [{spineItem: getDisplayingViews()[0].currentSpineItem(), $iframe: getDisplayingViews()[0].iframe()}];
+        } catch (err) {
+            return undefined;
+        }
+    };
+
+
+    this.hide = function() {
+        _.forEach(getDisplayingViews(), function(one_page_view) {
+            one_page_view.hideIFrame();
+        });
+    };
+
+    this.show = function() {
+        _.forEach(getDisplayingViews(), function(one_page_view) {
+            one_page_view.showIFrame();
+        });
+    };
+
+    this.setCached = function(isCached) {
+        _.forEach(getDisplayingViews(), function(one_page_view) {
+            one_page_view.setCached(isCached);
+        });
+    };
 
 };
     return FixedView;

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -46,7 +46,7 @@ var FixedView = function(options){
     var _zoom = options.zoom || {style: 'default'};
     var _currentScale;
     var _iframeLoader = options.iframeLoader;
-    var _viewSettings = undefined;
+    var _viewSettings = options.viewSettings;
 
     var _cached = options.cachedView || false;
 

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -70,7 +70,7 @@ var FixedView = function(options){
         var pageView = new OnePageView(options,
         [elementClass],
         false, //enableBookStyleOverrides
-        options.settings,
+        _viewSettings,
         _cached
         );
 

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -162,6 +162,7 @@ var FixedView = function(options){
                                                               {pageView: _centerPageView, spineItem: _spread.centerItem, context: context}]);
 
         $.when.apply($, pageLoadDeferrals).done(function(){
+            self.setCached(_cached);
             _isRedrowing = false;
 
             if(_redrawRequest) {
@@ -697,6 +698,7 @@ var FixedView = function(options){
     };
 
     this.setCached = function(isCached) {
+        _cached = isCached;
         _.forEach(getDisplayingViews(), function(one_page_view) {
             one_page_view.setCached(isCached);
         });

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -1,26 +1,26 @@
 //  Created by Boris Schneiderman.
 //  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
-//  
-//  Redistribution and use in source and binary forms, with or without modification, 
+//
+//  Redistribution and use in source and binary forms, with or without modification,
 //  are permitted provided that the following conditions are met:
-//  1. Redistributions of source code must retain the above copyright notice, this 
+//  1. Redistributions of source code must retain the above copyright notice, this
 //  list of conditions and the following disclaimer.
-//  2. Redistributions in binary form must reproduce the above copyright notice, 
-//  this list of conditions and the following disclaimer in the documentation and/or 
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//  this list of conditions and the following disclaimer in the documentation and/or
 //  other materials provided with the distribution.
-//  3. Neither the name of the organization nor the names of its contributors may be 
-//  used to endorse or promote products derived from this software without specific 
+//  3. Neither the name of the organization nor the names of its contributors may be
+//  used to endorse or promote products derived from this software without specific
 //  prior written permission.
-//  
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
-//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define (["jquery", "underscore", "eventEmitter", "../models/bookmark_data", "../models/current_pages_info",
@@ -89,7 +89,7 @@ var FixedView = function(options){
     this.setZoom = function(zoom){
         _zoom = zoom;
 
-        resizeBook(false); 
+        resizeBook(false);
     }
 
     this.render = function(){
@@ -99,9 +99,9 @@ var FixedView = function(options){
         _$el = $(template);
 
         Helpers.CSSTransition(_$el, "all 0 ease 0");
-        
+
         _$el.css("overflow", "hidden");
-        
+
         // Removed, see one_page_view@render()
         // var settings = reader.viewerSettings();
         // if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
@@ -114,7 +114,7 @@ var FixedView = function(options){
         //     // This fixes rendering issues with WebView (native apps), which crops content embedded in iframes unless GPU hardware acceleration is enabled for CSS rendering.
         //     _$el.css("transform", "translateZ(0)");
         // }
-        
+
         _$viewport.append(_$el);
 
         self.applyStyles();
@@ -129,9 +129,9 @@ var FixedView = function(options){
 
 
     this.setViewSettings = function(settings) {
-        
+
         _viewSettings = settings;
-        
+
         _spread.setSyntheticSpread(Helpers.deduceSyntheticSpread(_$viewport, getFirstVisibleItem(), _viewSettings) == true); // force boolean value (from truthy/falsey return value)
 
         var views = getDisplayingViews();
@@ -203,7 +203,7 @@ var FixedView = function(options){
         //     views[i].updatePageSwitchDir(dir, hasChanged);
         // }
     };
-    
+
 
     this.applyStyles = function() {
 
@@ -294,7 +294,7 @@ var FixedView = function(options){
     function resizeBook(viewportIsResizing) {
 
         updatePageSwitchDir(0, false);
-        
+
         if(!isContentRendered()) {
             return;
         }
@@ -320,9 +320,9 @@ var FixedView = function(options){
 
         var horScale = potentialContentSize.width / _contentMetaSize.width;
         var verScale = potentialContentSize.height / _contentMetaSize.height;
-        
+
         _$viewport.css("overflow", "auto");
-            
+
         var scale;
         if (_zoom.style == 'fit-width'){
             scale = horScale;
@@ -357,7 +357,7 @@ var FixedView = function(options){
 
         if(bookLeft < 0) bookLeft = 0;
         if(bookTop < 0) bookTop = 0;
-        
+
         _$el.css("left", bookLeft + "px");
         _$el.css("top", bookTop + "px");
         _$el.css("width", targetElementSize.width + "px");
@@ -388,7 +388,7 @@ var FixedView = function(options){
 
             _centerPageView[transFunc](scale, left, top);
         }
-        
+
         self.emit(Globals.Events.FXL_VIEW_RESIZED);
     }
 
@@ -475,13 +475,13 @@ var FixedView = function(options){
         var isSyntheticSpread = Helpers.deduceSyntheticSpread(_$viewport, paginationRequest.spineItem, _viewSettings) == true; // force boolean value (from truthy/falsey return value)
         _spread.setSyntheticSpread(isSyntheticSpread);
         _spread.openItem(paginationRequest.spineItem);
-        
+
         var hasChanged = leftItem !== _spread.leftItem || rightItem !== _spread.rightItem || centerItem !== _spread.centerItem;
-        
+
         if (dir === null || typeof dir === "undefined") dir = 0;
-        
+
         updatePageSwitchDir(dir === 0 ? 0 : (_spread.spine.isRightToLeft() ? (dir === 1 ? 2 : 1) : dir), hasChanged);
-        
+
         redraw(paginationRequest.initiator, paginationRequest);
     };
 
@@ -489,18 +489,18 @@ var FixedView = function(options){
     this.openPagePrev = function(initiator) {
 
         _spread.openPrev();
-        
+
         updatePageSwitchDir(_spread.spine.isRightToLeft() ? 2 : 1, true);
-        
+
         redraw(initiator, undefined);
     };
 
     this.openPageNext = function(initiator) {
 
         _spread.openNext();
-        
+
         updatePageSwitchDir(_spread.spine.isRightToLeft() ? 1 : 2, true);
-        
+
         redraw(initiator, undefined);
     };
 

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -30,10 +30,9 @@ define (["jquery", "underscore", "eventEmitter", "../models/bookmark_data", "../
 /**
  * View for rendering fixed layout page spread
  * @param options
- * @param reader
  * @constructor
  */
-var FixedView = function(options, reader){
+var FixedView = function(options){
 
     _.extend(this, new EventEmitter());
 
@@ -71,7 +70,7 @@ var FixedView = function(options, reader){
         var pageView = new OnePageView(options,
         [elementClass],
         false, //enableBookStyleOverrides
-        reader,
+        options.settings,
         _cached
         );
 

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -76,9 +76,9 @@ var FixedView = function(options){
 
         pageView.on(OnePageView.SPINE_ITEM_OPEN_START, function($iframe, spineItem) {
 
-            self.emit(Globals.Events.CONTENT_DOCUMENT_LOAD_START, $iframe, spineItem);
-        });   
-    
+            self.onContentDocumentLoadStart(spineItem);
+        });
+
         return pageView;
     }
 
@@ -242,8 +242,7 @@ var FixedView = function(options){
 
         updateContentMetaSize();
         resizeBook();
-        
-        self.emit(Globals.InternalEvents.CURRENT_VIEW_PAGINATION_CHANGED, { paginationInfo: self.getPaginationInfo(), initiator: initiator, spineItem: paginationRequest_spineItem, elementId: paginationRequest_elementId } );
+        self.onCurrentViewPaginationChanged(initiator, paginationRequest_spineItem, paginationRequest_elementId);
     }
 
     this.onViewportResize = function() {
@@ -534,7 +533,7 @@ var FixedView = function(options){
                         console.error("Invalid document " + spineItem.href + ": viewport is not specified!");
                     }
 
-                    self.emit(Globals.Events.CONTENT_DOCUMENT_LOADED, $iframe, spineItem);
+                    self.onContentDocumentLoaded(spineItem);
                 }
 
                 dfd.resolve();
@@ -602,6 +601,12 @@ var FixedView = function(options){
         }
 
         return views;
+    }
+
+    function findPageViewForSpineItem(spineItem) {
+        return _.find(_pageViews, function(pageView) {
+            return pageView.currentSpineItem() === spineItem;
+        });
     }
 
     this.getLoadedSpineItems = function() {
@@ -694,6 +699,24 @@ var FixedView = function(options){
         });
     };
 
+    this.onContentDocumentLoadStart = function(spineItem, pageView) {
+        pageView = pageView || findPageViewForSpineItem(spineItem);
+        self.emit(Globals.Events.CONTENT_DOCUMENT_LOAD_START, pageView.iframe, spineItem);
+    };
+
+    this.onContentDocumentLoaded = function(spineItem, pageView) {
+        pageView = pageView || findPageViewForSpineItem(spineItem);
+        self.emit(Globals.Events.CONTENT_DOCUMENT_LOADED, pageView.iframe, spineItem);
+    };
+
+    this.onCurrentViewPaginationChanged = function(initiator, spineItem, elementId) {
+        self.emit(Globals.InternalEvents.CURRENT_VIEW_PAGINATION_CHANGED, {
+            paginationInfo: self.getPaginationInfo(),
+            initiator: initiator,
+            spineItem: spineItem,
+            elementId: elementId
+        });
+    };
 };
     return FixedView;
 });

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -675,16 +675,6 @@ var FixedView = function(options){
 
     }
 
-    this.getLoadedContentFrames = function () {
-        // TODODM this needs to be fixed properly. Most likely, the cacheman needs to track what spines are attached to what views?
-        try {
-            return [{spineItem: getDisplayingViews()[0].currentSpineItem(), $iframe: getDisplayingViews()[0].iframe()}];
-        } catch (err) {
-            return undefined;
-        }
-    };
-
-
     this.hide = function() {
         _.forEach(getDisplayingViews(), function(one_page_view) {
             one_page_view.hideIFrame();

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -123,7 +123,17 @@ var FixedView = function(options){
     };
 
     this.remove = function() {
+        _leftPageView.remove();
+        _leftPageView = null;
 
+        _centerPageView.remove();
+        _centerPageView = null;
+
+        _rightPageView.remove();
+        _rightPageView = null;
+
+        _pageViews = null;
+        
         _$el.remove();
     };
 

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -35,7 +35,7 @@ define(["jquery", "underscore", "eventEmitter", "./cfi_navigation_logic", "../he
  * @param enableBookStyleOverrides
  * @constructor
  */
-var OnePageView = function (options, classes, enableBookStyleOverrides, reader) {
+var OnePageView = function (options, classes, enableBookStyleOverrides, reader, cached) {
 
     _.extend(this, new EventEmitter());
 
@@ -48,7 +48,7 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
     var _spine = options.spine;
     var _iframeLoader = options.iframeLoader;
     var _bookStyles = options.bookStyles;
-
+    var _cached = cached;
     var _$viewport = options.$viewport;
 
     var _isIframeLoaded = false;
@@ -430,6 +430,10 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
     var _useCSSTransformToHideIframe = true;
 
     this.showIFrame = function () {
+
+        if (_cached) {
+            return;
+        }
 
         _$iframe.css("visibility", "visible");
 
@@ -909,6 +913,16 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
         }
         return undefined;
     }
+
+    this.iframe = function () {
+        return _$iframe;
+    }
+
+
+    this.setCached = function(isCached) {
+        _cached = isCached;
+    };
+
 };
 
 OnePageView.SPINE_ITEM_OPEN_START = "SpineItemOpenStart";

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -303,7 +303,7 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, settings
         Helpers.CSSTransition(_$el, "all 0 ease 0");
 
         _$el.css("transform", "none");
-    
+
         if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
         {
             //defaults
@@ -314,7 +314,7 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, settings
             // This fixes rendering issues with WebView (native apps), which crops content embedded in iframes unless GPU hardware acceleration is enabled for CSS rendering.
             _$el.css("transform", "translateZ(0)");
         }
-    
+
         _$el.css("height", "100%");
         _$el.css("width", "100%");
 

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -297,18 +297,19 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader, 
         Helpers.CSSTransition(_$el, "all 0 ease 0");
 
         _$el.css("transform", "none");
+    
+        // var settings = reader.viewerSettings();
+        // if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
+        // {
+        //     //defaults
+        //     settings = new ViewerSettings({});
+        // }
+        // if (settings.enableGPUHardwareAccelerationCSS3D) {
 
-        var settings = reader.viewerSettings();
-        if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined") {
-            //defaults
-            settings = new ViewerSettings({});
-        }
-        if (settings.enableGPUHardwareAccelerationCSS3D) {
-
-            // This fixes rendering issues with WebView (native apps), which crops content embedded in iframes unless GPU hardware acceleration is enabled for CSS rendering.
-            _$el.css("transform", "translateZ(0)");
-        }
-
+        //     // This fixes rendering issues with WebView (native apps), which crops content embedded in iframes unless GPU hardware acceleration is enabled for CSS rendering.
+        //     _$el.css("transform", "translateZ(0)");
+        // }
+    
         _$el.css("height", "100%");
         _$el.css("width", "100%");
 
@@ -539,8 +540,10 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader, 
             enable3D = true;
         }
 
-        if (reader.needsFixedLayoutScalerWorkAround()) {
-            var css1 = Helpers.CSSTransformString({scale: scale, enable3D: enable3D});
+        // if (reader.needsFixedLayoutScalerWorkAround())
+        if(false)
+        {
+            var css1 = Helpers.CSSTransformString({scale : scale, enable3D: enable3D});
             _$epubHtml.css(css1);
 
             var css2 = Helpers.CSSTransformString({scale : 1, enable3D: enable3D});

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -55,6 +55,8 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, settings
 
     var _$scaler;
 
+    var _needsFixedLayoutScalerWorkAround = options.needsFixedLayoutScalerWorkAround || false;
+
     var PageTransitionHandler = function (opts) {
         var PageTransition = function (begin, end) {
             this.begin = begin;
@@ -539,8 +541,7 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, settings
             enable3D = true;
         }
 
-        // if (reader.needsFixedLayoutScalerWorkAround())
-        if(false)
+        if(_needsFixedLayoutScalerWorkAround)
         {
             var css1 = Helpers.CSSTransformString({scale : scale, enable3D: enable3D});
             _$epubHtml.css(css1);

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -917,11 +917,6 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, settings
         return undefined;
     }
 
-    this.iframe = function () {
-        return _$iframe;
-    }
-
-
     this.setCached = function(isCached) {
         _cached = isCached;
     };

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -275,6 +275,10 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, settings
         return _$el;
     };
 
+    this.iframe = function() {
+        return _$iframe;
+    };
+
     this.meta_height = function () {
         return _meta_size.height;
     };

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -35,7 +35,7 @@ define(["jquery", "underscore", "eventEmitter", "./cfi_navigation_logic", "../he
  * @param enableBookStyleOverrides
  * @constructor
  */
-var OnePageView = function (options, classes, enableBookStyleOverrides, reader, cached) {
+var OnePageView = function (options, classes, enableBookStyleOverrides, settings, cached) {
 
     _.extend(this, new EventEmitter());
 
@@ -298,17 +298,16 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader, 
 
         _$el.css("transform", "none");
     
-        // var settings = reader.viewerSettings();
-        // if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
-        // {
-        //     //defaults
-        //     settings = new ViewerSettings({});
-        // }
-        // if (settings.enableGPUHardwareAccelerationCSS3D) {
+        if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
+        {
+            //defaults
+            settings = new ViewerSettings({});
+        }
+        if (settings.enableGPUHardwareAccelerationCSS3D) {
 
-        //     // This fixes rendering issues with WebView (native apps), which crops content embedded in iframes unless GPU hardware acceleration is enabled for CSS rendering.
-        //     _$el.css("transform", "translateZ(0)");
-        // }
+            // This fixes rendering issues with WebView (native apps), which crops content embedded in iframes unless GPU hardware acceleration is enabled for CSS rendering.
+            _$el.css("transform", "translateZ(0)");
+        }
     
         _$el.css("height", "100%");
         _$el.css("width", "100%");

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -336,9 +336,19 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, settings
     };
 
     this.remove = function () {
+        _$epubHtml.remove();
+        _$epubHtml = null;
+
+        _$iframe.remove();
+        _$iframe = null;
+
+        _$scaler.remove();
+        _$scaler = null;
+        
         _isIframeLoaded = false;
         _currentSpineItem = undefined;
         _$el.remove();
+        _$el = null;
     };
 
     this.clear = function () {

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -242,33 +242,34 @@ var ReaderView = function (options) {
     };
 
 
+    // TODODM: this needs to take spine item as a parameter, not an index. maybe.
     function createPrefetchedViewForSpineItemIndex(spineItemIndex, setToPage) {
         var spineItem = _spine.items[spineItemIndex];
         var cachedView = getCachedViewForSpineItem(spineItem);
         if (cachedView === undefined) {
-                var desiredViewType = deduceDesiredViewType(spineItem);
+            var desiredViewType = deduceDesiredViewType(spineItem);
 
-                var viewCreationParams = {
-                    $viewport: _$el,
-                    spine: _spine,
-                    userStyles: _userStyles,
-                    bookStyles: _bookStyles,
-                    iframeLoader: _iframeLoader,
-                    cachedView: true
-                };
+            var viewCreationParams = {
+                $viewport: _$el,
+                spine: _spine,
+                userStyles: _userStyles,
+                bookStyles: _bookStyles,
+                iframeLoader: _iframeLoader,
+                cachedView: true
+            };
 
-                cachedView = self.createViewForType(desiredViewType, viewCreationParams);
-                var openPageRequest = new PageOpenRequest(spineItem, self);
-                if (setToPage === "last") {
-                    openPageRequest.setLastPage();
-                } else {
-                    openPageRequest.setFirstPage();
-                }
+            cachedView = self.createViewForType(desiredViewType, viewCreationParams);
+            var openPageRequest = new PageOpenRequest(spineItem, self);
+            if (setToPage === "last") {
+                openPageRequest.setLastPage();
+            } else {
+                openPageRequest.setFirstPage();
+            }
 
-                cachedView.render();
-                cachedView.setViewSettings(_viewerSettings);
-                cachedView.openPage(openPageRequest,2);
-                cachedView.setCached(true);
+            cachedView.render();
+            cachedView.setViewSettings(_viewerSettings);
+            cachedView.openPage(openPageRequest,2);
+            cachedView.setCached(true);
         }
         return cachedView;
     };

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -119,7 +119,7 @@ var ReaderView = function (options) {
             bookStyles: _bookStyles,
             iframeLoader: _iframeLoader,
         };
-        _currentView = _viewManager.getViewForSpineItem(spineItem, _currentView, _viewerSettings, viewCreationParams);
+        _currentView = _viewManager.getViewForSpineItem(spineItem, _currentView, _viewerSettings, viewCreationParams, callback);
 
         self.emit(Globals.Events.READER_VIEW_CREATED, _viewManager.viewTypeForView(_currentView));
 
@@ -137,10 +137,6 @@ var ReaderView = function (options) {
             Switches.apply(contentDoc);
 
             self.emit(Globals.Events.CONTENT_DOCUMENT_LOADED, $iframe, spineItem);
-
-            // if (_.isUndefined(getCachedViewForSpineItem(_currentView.getLoadedSpineItems()[0]))) {
-            //     _cachedViews.push(_currentView);
-            // }
         });
 
         _currentView.on(Globals.Events.CONTENT_DOCUMENT_LOAD_START, function ($iframe, spineItem) {

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -95,11 +95,10 @@ var ReaderView = function (options) {
     /**
      * @returns {boolean}
      */
-    this.needsFixedLayoutScalerWorkAround = function () {
-        return _needsFixedLayoutScalerWorkAround;
+    this.needsFixedLayoutScalerWorkAround = function() {
+      return _needsFixedLayoutScalerWorkAround;
     };
 
- 
     /**
      * Returns the current view type of the reader view
      * @returns {ReaderView.ViewType}
@@ -154,9 +153,9 @@ var ReaderView = function (options) {
             self.emit(Globals.Events.PAGINATION_CHANGED, pageChangeData);
         });
 
-        _currentView.on(Globals.Events.FXL_VIEW_RESIZED, function () {
+        _currentView.on(Globals.Events.FXL_VIEW_RESIZED, function() {
             self.emit(Globals.Events.FXL_VIEW_RESIZED);
-        })
+        });
 
         _currentView.on(Globals.Events.CONTENT_DOCUMENT_LOAD_START, function($iframe, spineItem) {
             self.emit(Globals.Events.CONTENT_DOCUMENT_LOAD_START, $iframe, spineItem);
@@ -490,7 +489,7 @@ var ReaderView = function (options) {
 
         var paginationInfo = _currentView.getPaginationInfo();
 
-        if (paginationInfo.openPages.length == 0) {
+        if (paginationInfo.openPages.length === 0) {
             return;
         }
 
@@ -527,7 +526,7 @@ var ReaderView = function (options) {
 
         var paginationInfo = _currentView.getPaginationInfo();
 
-        if (paginationInfo.openPages.length == 0) {
+        if (paginationInfo.openPages.length === 0) {
             return;
         }
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -277,6 +277,7 @@ var ReaderView = function (options) {
 
     // returns true is view changed
     function initViewForItem(spineItem, callback) {
+        console.log('%c Init view for item', 'background: black; color: red');
         if (_currentView) {
             _currentView.hide();
             _currentView.setCached(true);
@@ -305,7 +306,9 @@ var ReaderView = function (options) {
                         _cachedViews.push(view);    
                     } else {
                         console.debug('%c Prevented from loading duplicate view...%d cached views', 'background: grey; color: red', _cachedViews.length);
+                        console.debug("fixed-book-frame:", $('.fixed-book-frame', _$el).length);
                         view.hide();
+                        view.remove();
                         delete view;
                     }
                 })
@@ -314,12 +317,12 @@ var ReaderView = function (options) {
             var rightSpineItemToPrefetch = _spine.items[spineItem.index + spinesWithinTheCurrentView];
             var leftSpineItemToPrefetch = _spine.items[spineItem.index - spinesWithinTheCurrentView];
 
-            if (rightSpineItemToPrefetch.index < _spine.items.length && _.isUndefined(getCachedViewForSpineItem(rightSpineItemToPrefetch))) {
+            if (rightSpineItemToPrefetch && _.isUndefined(getCachedViewForSpineItem(rightSpineItemToPrefetch))) {
                 var rightView = createPrefetchedViewForSpineItemIndex(rightSpineItemToPrefetch.index);
                 saveViewOnceLoaded(rightView);
             }
 
-            if (leftSpineItemToPrefetch.index > 0 && _.isUndefined(getCachedViewForSpineItem(leftSpineItemToPrefetch))) {
+            if (leftSpineItemToPrefetch && _.isUndefined(getCachedViewForSpineItem(leftSpineItemToPrefetch))) {
                  var leftView = createPrefetchedViewForSpineItemIndex(leftSpineItemToPrefetch.index, "last");
                  saveViewOnceLoaded(leftView);
             }

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -279,7 +279,7 @@ var ReaderView = function (options) {
         if (_currentView) {
             _currentView.hide();
             _currentView.setCached(true);
-
+            _currentView.off();
         }
 
         var cachedView = getCachedViewForSpineItem(spineItem);

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -66,6 +66,7 @@ var ReaderView = function (options) {
     var _iframeLoader;
     var _$el;
     var _prefetchingEnabled = true;
+    var _cacheManager = new ReadiumSDK.Models.CacheManager();
     
     //We will call onViewportResize after user stopped resizing window
     var lazyResize = Helpers.extendedThrottle(
@@ -197,12 +198,7 @@ var ReaderView = function (options) {
 
 
     function createViewForItem(spineItem, callback) {
-        console.debug("-----");
-        _.each(_cachedViews, function(view) {
-            _.each(view.getLoadedSpineItems(), function(spine){
-                console.debug("Cached:", spine.index, ' href:', spine.href);
-            });
-        });
+
         var view = undefined;
         var desiredViewType = deduceDesiredViewType(spineItem);
 
@@ -228,77 +224,8 @@ var ReaderView = function (options) {
         return view;
     }
 
-    // we need to find whether we've already cached a particular spine item. 
-    // lets ask all of the existing views for the spine items that they are 
-    // holding (remember, each view may hold more than one)
-    function getCachedViewForSpineItem(spineItem) {
-        return _.find(_cachedViews, function(view){
-            var loadedspines = view.getLoadedSpineItems();
-            var foundView = _.find(loadedspines, function(spine) {
-                 return spine.index === spineItem.index;
-            });
-            return foundView;
-        });
-    };
-
-
-    // TODODM: this needs to take spine item as a parameter, not an index. maybe.
-    function createPrefetchedViewForSpineItemIndex(spineItemIndex, setToPage) {
-        var spineItem = _spine.items[spineItemIndex];
-        var cachedView = getCachedViewForSpineItem(spineItem);
-        if (cachedView === undefined) {
-            var desiredViewType = deduceDesiredViewType(spineItem);
-
-            var viewCreationParams = {
-                $viewport: _$el,
-                spine: _spine,
-                userStyles: _userStyles,
-                bookStyles: _bookStyles,
-                iframeLoader: _iframeLoader,
-                cachedView: true
-            };
-
-            cachedView = self.createViewForType(desiredViewType, viewCreationParams);
-            var openPageRequest = new PageOpenRequest(spineItem, self);
-            if (setToPage === "last") {
-                openPageRequest.setLastPage();
-            } else {
-                openPageRequest.setFirstPage();
-            }
-
-            cachedView.render();
-            cachedView.setViewSettings(_viewerSettings);
-            cachedView.openPage(openPageRequest,2);
-            cachedView.setCached(true);
-            cachedView.hide();
-        }
-        return cachedView;
-    };
-
-
-    function expireCachedItems(currentSpineItem) {
-        var currentSpineItemIndex = currentSpineItem.index;
-        // get all views that have an spine index more than 3 removed. it's simplistic but should work
-        // for both single and double fixed page layouts..
-        var cachedViewsToRemove = _.filter(_cachedViews, function(cachedView){
-            var spineItemForCachedView = cachedView.getLoadedSpineItems()[0];
-            return (Math.abs(spineItemForCachedView.index - currentSpineItemIndex) > 3); 
-        });
-
-        console.log("Pruning cached views, removing %d from the cached views list.", cachedViewsToRemove.length);
-
-        // remove views from the dom.
-        _.each(cachedViewsToRemove, function(viewToRemove) {
-            viewToRemove.remove();
-        });
-
-        // remove cached views from our local table.
-        _cachedViews = _.difference(_cachedViews, cachedViewsToRemove);
-    }
-
     // returns true is view changed
     function initViewForItem(spineItem, callback) {
-        expireCachedItems(spineItem);
         console.log('%c Init view for item', 'background: black; color: red');
         if (_currentView) {
             _currentView.hide();

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -118,6 +118,7 @@ var ReaderView = function (options) {
             userStyles: _userStyles,
             bookStyles: _bookStyles,
             iframeLoader: _iframeLoader,
+            needsFixedLayoutScalerWorkAround: self.needsFixedLayoutScalerWorkAround()
         };
         _currentView = _viewManager.getViewForSpineItem(spineItem, _currentView, _viewerSettings, viewCreationParams, callback);
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -225,7 +225,11 @@ var ReaderView = function (options) {
     function getCachedViewForSpineItem(spineItem) {
         var cached = _.filter(_cachedViews, 
             function(view) { 
-                return view.getLoadedContentFrames()[0].spineItem.index === spineItem.index;
+                var loadedspines = view.getLoadedContentFrames();
+                if (loadedspines !== undefined) {
+                    return loadedspines[0].spineItem.index === spineItem.index;
+                } 
+                return false;
             });
         return cached[0];
     };
@@ -253,21 +257,25 @@ var ReaderView = function (options) {
                 cachedView.render();
                 cachedView.openPage(openPageRequest,2);
                 cachedView.setViewSettings(_viewerSettings);
+                cachedView.setCached(true);
         }
         return cachedView;
     };
 
     // returns true is view changed
     function initViewForItem(spineItem, callback) {
+        if (_currentView) {
+            _currentView.hide();
+        }
         var cachedView = getCachedViewForSpineItem(spineItem);
-
 
         _cachedViews.push(createPrefetchedViewForSpineItemIndex(spineItem.index+1));
 
+        _cachedViews.push(createPrefetchedViewForSpineItemIndex(spineItem.index+2));
 
         // there's a cached view!
         var newCurrentViewIsCached = false;
-        if (!(cachedView === undefined)) {
+        if (cachedView !== undefined) {
             _currentView.hide();
             _currentView.setCached(true);
             cachedView.show();

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -270,6 +270,7 @@ var ReaderView = function (options) {
             cachedView.setViewSettings(_viewerSettings);
             cachedView.openPage(openPageRequest,2);
             cachedView.setCached(true);
+            cachedView.hide();
         }
         return cachedView;
     };
@@ -303,7 +304,9 @@ var ReaderView = function (options) {
                         console.log('%c View loaded in the background...%d cached views', 'background: grey; color: blue', _cachedViews.length);
                         _cachedViews.push(view);    
                     } else {
-                        console.debug('%c Prevented from loading duplicate view...%d cached views', 'background: grey; color: red', _cachedViews.length);                        
+                        console.debug('%c Prevented from loading duplicate view...%d cached views', 'background: grey; color: red', _cachedViews.length);
+                        view.hide();
+                        delete view;
                     }
                 })
             };
@@ -392,6 +395,11 @@ var ReaderView = function (options) {
         setTimeout(function () {
 
             callback(true);
+            _.each(_cachedViews, function(view) {
+                if (view !== _currentView) {
+                    view.hide();
+                }
+            });
 
         }, 50);
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -126,7 +126,8 @@ var ReaderView = function (options) {
             userStyles: _userStyles,
             bookStyles: _bookStyles,
             iframeLoader: _iframeLoader,
-            needsFixedLayoutScalerWorkAround: self.needsFixedLayoutScalerWorkAround()
+            needsFixedLayoutScalerWorkAround: self.needsFixedLayoutScalerWorkAround(),
+            viewSettings: _viewerSettings
         };
         _currentView = _viewManager.getViewForSpineItem(spineItem, _currentView, _viewerSettings, viewCreationParams, callback);
 
@@ -274,7 +275,7 @@ var ReaderView = function (options) {
 
         _mediaOverlayDataInjector = new MediaOverlayDataInjector(_package.media_overlay, _mediaOverlayPlayer);
 
-        _viewManager = new ViewManager(_spine);
+        _viewManager = new ViewManager(_spine, self);
 
 
         resetCurrentView();

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -161,10 +161,10 @@ var ReaderView = function (options) {
             self.emit(Globals.Events.CONTENT_DOCUMENT_LOAD_START, $iframe, spineItem);
         });
 
-        // we do this to wait until elements are rendered otherwise book is not able to determine view size.
-        setTimeout(function(){
-            callback(true);
-        }, 50);
+        // // we do this to wait until elements are rendered otherwise book is not able to determine view size.
+        // setTimeout(function(){
+        //     callback(true);
+        // }, 50);
 
     }
 
@@ -633,19 +633,13 @@ var ReaderView = function (options) {
 
     // dir: 0 => new or same page, 1 => previous, 2 => next
     function openPage(pageRequest, dir) {
-
-        // 1. check if a spine item is already cached, if so, set the current view to it
-        //    and cache around it.
-        // 2. if the spine item is not cached, do the normal thing.
-
-
-        initViewForItem(pageRequest.spineItem, function(isViewChanged){
+        initViewForItem(pageRequest.spineItem, function(isViewChanged, newView){
 
             if (!isViewChanged) {
                 _currentView.setViewSettings(_viewerSettings);
             }
 
-            _currentView.openPage(pageRequest, dir);
+            newView.openPage(pageRequest, dir);
         });
     }
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -1,37 +1,37 @@
 //  Created by Boris Schneiderman.
 // Modified by Daniel Weck
 //  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
-//  
-//  Redistribution and use in source and binary forms, with or without modification, 
+//
+//  Redistribution and use in source and binary forms, with or without modification,
 //  are permitted provided that the following conditions are met:
-//  1. Redistributions of source code must retain the above copyright notice, this 
+//  1. Redistributions of source code must retain the above copyright notice, this
 //  list of conditions and the following disclaimer.
-//  2. Redistributions in binary form must reproduce the above copyright notice, 
-//  this list of conditions and the following disclaimer in the documentation and/or 
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//  this list of conditions and the following disclaimer in the documentation and/or
 //  other materials provided with the distribution.
-//  3. Neither the name of the organization nor the names of its contributors may be 
-//  used to endorse or promote products derived from this software without specific 
+//  3. Neither the name of the organization nor the names of its contributors may be
+//  used to endorse or promote products derived from this software without specific
 //  prior written permission.
-//  
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
-//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(["jquery", "underscore", "eventEmitter", "./fixed_view", "../helpers", "./iframe_loader", "./internal_links_support",
         "./media_overlay_data_injector", "./media_overlay_player", "../models/package", "../models/page_open_request",
         "./reflowable_view", "./scroll_view", "../models/style_collection", "../models/switches", "../models/trigger",
-        "../models/viewer_settings", "../globals"],
+        "../models/viewer_settings", "../globals", "../models/view_manager"],
     function ($, _, EventEmitter, FixedView, Helpers, IFrameLoader, InternalLinksSupport,
               MediaOverlayDataInjector, MediaOverlayPlayer, Package, PageOpenRequest,
               ReflowableView, ScrollView, StyleCollection, Switches, Trigger,
-              ViewerSettings, Globals) {
+              ViewerSettings, Globals, ViewManager) {
 /**
  * Options passed on the reader from the readium loader/initializer
  *
@@ -66,7 +66,7 @@ var ReaderView = function (options) {
     var _$el;
     var _prefetchingEnabled = true;
     var _viewManager; // in openbook.
-    
+
     //We will call onViewportResize after user stopped resizing window
     var lazyResize = Helpers.extendedThrottle(
         handleViewportResizeStart,

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -297,8 +297,14 @@ var ReaderView = function (options) {
                     return;
                 }
                 view.once(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, function() {
-                    console.log('%c View loaded in the background...%d cached views', 'background: grey; color: blue', _cachedViews.length);
-                    _cachedViews.push(view);    
+                    // try to make sure that we don't load duplicate views.
+                    var spineItemForView = view.getLoadedSpineItems()[0];
+                    if (_.isUndefined(getCachedViewForSpineItem(spineItemForView))) {
+                        console.log('%c View loaded in the background...%d cached views', 'background: grey; color: blue', _cachedViews.length);
+                        _cachedViews.push(view);    
+                    } else {
+                        console.debug('%c Prevented from loading duplicate view...%d cached views', 'background: grey; color: red', _cachedViews.length);                        
+                    }
                 })
             };
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -111,6 +111,15 @@ var ReaderView = function (options) {
     // returns true is view changed
     function initViewForItem(spineItem, callback) {
         console.log('%c Init view for item', 'background: black; color: red');
+        /**
+         * View creation options
+         * @typedef {object} ReaderView.ViewCreationOptions
+         * @property {jQueryElement} $viewport  The view port element the reader view has created.
+         * @property {Models.Spine} spine The spine item collection object
+         * @property {Collections.StyleCollection} userStyles User styles
+         * @property {Collections.StyleCollection} bookStyles Book styles
+         * @property {IFrameLoader} iframeLoader   An instance of an iframe loader or one expanding it.
+         */
         var viewCreationParams = {
             $viewport: _$el,
             spine: _spine,
@@ -1327,17 +1336,5 @@ var ReaderView = function (options) {
     this.backgroundAudioTrackManager = new BackgroundAudioTrackManager();
 };
 
-/**
- * View Type
- * @typedef {object} Globals.Views.ReaderView.ViewType
- * @property {number} VIEW_TYPE_COLUMNIZED          Reflowable document view
- * @property {number} VIEW_TYPE_FIXED               Fixed layout document view
- * @property {number} VIEW_TYPE_SCROLLED_DOC        Scrollable document view
- * @property {number} VIEW_TYPE_SCROLLED_CONTINUOUS Continuous scrollable document view
- */
-ReaderView.VIEW_TYPE_COLUMNIZED = 1;
-ReaderView.VIEW_TYPE_FIXED = 2;
-ReaderView.VIEW_TYPE_SCROLLED_DOC = 3;
-ReaderView.VIEW_TYPE_SCROLLED_CONTINUOUS = 4;
 return ReaderView;
 });

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -222,17 +222,17 @@ var ReaderView = function (options) {
         return view;
     }
 
-
+    // we need to find whether we've already cached a particular spine item. 
+    // lets ask all of the existing views for the spine items that they are 
+    // holding (remember, each view may hold more than one)
     function getCachedViewForSpineItem(spineItem) {
-        var cached = _.filter(_cachedViews, 
-            function(view) { 
-                var loadedspines = view.getLoadedContentFrames();
-                if (loadedspines !== undefined) {
-                    return loadedspines[0].spineItem.index === spineItem.index;
-                } 
-                return false;
+        return _.find(_cachedViews, function(view){
+            var loadedspines = view.getLoadedSpineItems();
+            var foundView = _.find(loadedspines, function(spine) {
+                 return spine.index === spineItem.index;
             });
-        return cached[0];
+            return foundView;
+        });
     };
 
 
@@ -284,8 +284,6 @@ var ReaderView = function (options) {
 
         // there's a cached view, lets reset the _currentView then.
         if (cachedView !== undefined) {
-            // _currentView.hide();
-            // _currentView.setCached(true);
             cachedView.setCached(false);
             cachedView.show();
             _currentView = cachedView;

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -275,8 +275,30 @@ var ReaderView = function (options) {
         return cachedView;
     };
 
+
+    function expireCachedItems(currentSpineItem) {
+        var currentSpineItemIndex = currentSpineItem.index;
+        // get all views that have an spine index more than 3 removed. it's simplistic but should work
+        // for both single and double fixed page layouts..
+        var cachedViewsToRemove = _.filter(_cachedViews, function(cachedView){
+            var spineItemForCachedView = cachedView.getLoadedSpineItems()[0];
+            return (Math.abs(spineItemForCachedView.index - currentSpineItemIndex) > 3); 
+        });
+
+        console.log("Pruning cached views, removing %d from the cached views list.", cachedViewsToRemove.length);
+
+        // remove views from the dom.
+        _.each(cachedViewsToRemove, function(viewToRemove) {
+            viewToRemove.remove();
+        });
+
+        // remove cached views from our local table.
+        _cachedViews = _.difference(_cachedViews, cachedViewsToRemove);
+    }
+
     // returns true is view changed
     function initViewForItem(spineItem, callback) {
+        expireCachedItems(spineItem);
         console.log('%c Init view for item', 'background: black; color: red');
         if (_currentView) {
             _currentView.hide();

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -265,7 +265,7 @@ var ReaderView = function (options) {
 
         _mediaOverlayDataInjector = new MediaOverlayDataInjector(_package.media_overlay, _mediaOverlayPlayer);
 
-        _viewManager = new CacheManager(_spine);
+        _viewManager = new ViewManager(_spine);
 
 
         resetCurrentView();

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -92,7 +92,8 @@ var ReflowableView = function(options, reader){
         _$el = $(template);
         _$viewport.append(_$el);
 
-        var settings = reader.viewerSettings();
+        // var settings = reader.viewerSettings();
+        var settings;
         if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
         {
             //defaults

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -109,6 +109,8 @@ var ReflowableView = function(options) {
         // $(window).on("resize.ReadiumSDK.reflowableView", _.bind(lazyResize, self));
         renderIframe();
 
+        self.hide();
+
         return self;
     };
 
@@ -224,7 +226,6 @@ var ReflowableView = function(options) {
         }
 
         if(!success) {
-            _$iframe.css("opacity", "1");
             _deferredPageRequest = undefined;
             return;
         }
@@ -300,10 +301,7 @@ var ReflowableView = function(options) {
         }
         
         _paginationInfo.isVerticalWritingMode = _htmlBodyIsVerticalWritingMode;
-        
-        hideBook();
-        _$iframe.css("opacity", "1");
-        
+
         updateViewportSize();
         _$epubHtml.css("height", _lastViewPortSize.height + "px");
         
@@ -441,8 +439,10 @@ var ReflowableView = function(options) {
             _$epubHtml.css("right", !ltr ? offsetVal : "");
         }
 
+        showBook(); // as it's no longer hidden by shifting the position
+
         if (!_cachedView) {
-            showBook(); // as it's no longer hidden by shifting the position
+            self.show();
         }
     }
 
@@ -705,6 +705,7 @@ var ReflowableView = function(options) {
 
     function hideBook()
     {
+        if (!_$epubHtml) return;
         if (_currentOpacity != -1) return; // already hidden
         
         _currentOpacity = _$epubHtml.css('opacity');
@@ -713,6 +714,8 @@ var ReflowableView = function(options) {
 
     function showBook()
     {
+        if (!_$epubHtml) return;
+
         if (_currentOpacity != -1)
         {
             _$epubHtml.css('opacity', _currentOpacity);
@@ -895,12 +898,15 @@ var ReflowableView = function(options) {
     }
 
     this.hide = function() {
-        _$el.hide();
+        _$iframe.css('opacity', '0.01');
+        _$iframe.hide();
+        _$contentFrame.css('visibility', 'hidden');
     };
 
     this.show = function() {
-        _$el.show();
-        showBook();
+        _$iframe.show();
+        _$iframe.css('opacity', '1');
+        _$contentFrame.css('visibility', 'visible');
     };
 
     this.setCached = function(isCached) {

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -450,10 +450,6 @@ var ReflowableView = function(options) {
 
         var newWidth = _$contentFrame.width();
 
-        // Ensure that the new viewport width is always even numbered
-        // this is to prevent a rendering inconsistency between browsers when odd-numbered bounds are used for CSS columns
-        newWidth -= newWidth % 2;
-
         var newHeight = _$contentFrame.height();
 
         if(_lastViewPortSize.width !== newWidth || _lastViewPortSize.height !== newHeight){

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -49,6 +49,7 @@ var ReflowableView = function(options) {
     var _bookStyles = options.bookStyles;
     var _iframeLoader = options.iframeLoader;
     var _cachedView = options.cachedView;
+    var _viewSettings = options.viewSettings;
     
     var _currentSpineItem;
     var _isWaitingFrameRender = false;    
@@ -137,7 +138,6 @@ var ReflowableView = function(options) {
         }
     };
 
-    var _viewSettings = undefined;
     this.setViewSettings = function(settings) {
         
         _viewSettings = settings;

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -897,10 +897,6 @@ var ReflowableView = function(options) {
         self.openPage(openPageRequest);
     }
 
-    this.getLoadedContentFrames = function () {
-        return [{spineItem: _currentSpineItem, $iframe: _$iframe}];
-    };
-
     this.hide = function() {
         _$el.hide();
     };

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -580,12 +580,12 @@ var ReflowableView = function(options) {
 // console.debug(fontSize);
 //         }
         
-        // // if (_viewSettings.fontSize)
-        // {
-        //     var fontSizeAdjust = (_viewSettings.fontSize*0.8)/100;
-        //     MAXW = Math.floor(MAXW * fontSizeAdjust);
-        //     MINW = Math.floor(MINW * fontSizeAdjust);
-        // }
+        // if (_viewSettings.fontSize)
+        {
+            var fontSizeAdjust = (_viewSettings.fontSize*0.8)/100;
+            MAXW = Math.floor(MAXW * fontSizeAdjust);
+            MINW = Math.floor(MINW * fontSizeAdjust);
+        }
         
         var availableWidth = _$viewport.width();
         var textWidth = availableWidth - borderLeft - borderRight - adjustedGapLeft - adjustedGapRight;

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -330,9 +330,6 @@ var ReflowableView = function(options, reader){
         updateHtmlFontSize();
         updateColumnGap();
         self.applyStyles();
-
-
-        self.applyStyles();
     }
 
     this.applyStyles = function() {

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -190,7 +190,7 @@ var ReflowableView = function(options) {
             _isWaitingFrameRender = true;
 
             var src = _spine.package.resolveRelativeUrl(spineItem.href);
-            self.emit(Globals.Events.CONTENT_DOCUMENT_LOAD_START, _$iframe, spineItem);
+            self.onContentDocumentLoadStart(spineItem);
 
             _$iframe.css("opacity", "0.01");
             
@@ -229,7 +229,7 @@ var ReflowableView = function(options) {
             return;
         }
 
-        self.emit(Globals.Events.CONTENT_DOCUMENT_LOADED, _$iframe, _currentSpineItem);
+        self.onContentDocumentLoaded(_currentSpineItem);
 
         var epubContentDocument = _$iframe[0].contentDocument;
         _$epubHtml = $("html", epubContentDocument);
@@ -466,7 +466,8 @@ var ReflowableView = function(options) {
         _paginationInfo.pageOffset = (_paginationInfo.columnWidth + _paginationInfo.columnGap) * _paginationInfo.visibleColumnCount * _paginationInfo.currentSpreadIndex;
         
         redraw();
-        self.emit(Globals.InternalEvents.CURRENT_VIEW_PAGINATION_CHANGED, { paginationInfo: self.getPaginationInfo(), initiator: initiator, spineItem: paginationRequest_spineItem, elementId: paginationRequest_elementId } );
+
+        self.onCurrentViewPaginationChanged(initiator, paginationRequest_spineItem, paginationRequest_elementId);
     }
 
     this.openPagePrev = function (initiator) {
@@ -906,8 +907,22 @@ var ReflowableView = function(options) {
         _cachedView = isCached;
     };
 
+    this.onContentDocumentLoadStart = function(spineItem) {
+        self.emit(Globals.Events.CONTENT_DOCUMENT_LOAD_START, _$iframe, spineItem);
+    };
 
+    this.onContentDocumentLoaded = function(spineItem) {
+        self.emit(Globals.Events.CONTENT_DOCUMENT_LOADED, _$iframe, spineItem);
+    };
 
+    this.onCurrentViewPaginationChanged = function(initiator, spineItem, elementId) {
+        self.emit(Globals.InternalEvents.CURRENT_VIEW_PAGINATION_CHANGED, {
+            paginationInfo: self.getPaginationInfo(),
+            initiator: initiator,
+            spineItem: spineItem,
+            elementId: elementId
+        });
+    };
 
 };
     return ReflowableView;

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -37,7 +37,7 @@ define(["jquery", "underscore", "eventEmitter", "../models/bookmark_data", "./cf
  * @param options
  * @constructor
  */
-var ReflowableView = function(options, reader){
+var ReflowableView = function(options) {
 
     _.extend(this, new EventEmitter());
 
@@ -92,8 +92,7 @@ var ReflowableView = function(options, reader){
         _$el = $(template);
         _$viewport.append(_$el);
 
-        // var settings = reader.viewerSettings();
-        var settings;
+        var settings = options.settings;
         if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
         {
             //defaults

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -3,27 +3,27 @@
 //
 //  Created by Boris Schneiderman.
 //  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
-//  
-//  Redistribution and use in source and binary forms, with or without modification, 
+//
+//  Redistribution and use in source and binary forms, with or without modification,
 //  are permitted provided that the following conditions are met:
-//  1. Redistributions of source code must retain the above copyright notice, this 
+//  1. Redistributions of source code must retain the above copyright notice, this
 //  list of conditions and the following disclaimer.
-//  2. Redistributions in binary form must reproduce the above copyright notice, 
-//  this list of conditions and the following disclaimer in the documentation and/or 
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//  this list of conditions and the following disclaimer in the documentation and/or
 //  other materials provided with the distribution.
-//  3. Neither the name of the organization nor the names of its contributors may be 
-//  used to endorse or promote products derived from this software without specific 
+//  3. Neither the name of the organization nor the names of its contributors may be
+//  used to endorse or promote products derived from this software without specific
 //  prior written permission.
-//  
-//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
-//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
-//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
-//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
 define(["jquery", "underscore", "eventEmitter", "../models/bookmark_data", "./cfi_navigation_logic",
@@ -42,7 +42,7 @@ var ReflowableView = function(options) {
     _.extend(this, new EventEmitter());
 
     var self = this;
-    
+
     var _$viewport = options.$viewport;
     var _spine = options.spine;
     var _userStyles = options.userStyles;
@@ -50,9 +50,9 @@ var ReflowableView = function(options) {
     var _iframeLoader = options.iframeLoader;
     var _cachedView = options.cachedView;
     var _viewSettings = options.viewSettings;
-    
+
     var _currentSpineItem;
-    var _isWaitingFrameRender = false;    
+    var _isWaitingFrameRender = false;
     var _deferredPageRequest;
     var _fontSize = 100;
     var _$contentFrame;
@@ -60,14 +60,14 @@ var ReflowableView = function(options) {
     var _$el;
     var _$iframe;
     var _$epubHtml;
-    
+
     var _$htmlBody;
-    
+
     var _htmlBodyIsVerticalWritingMode;
     var _htmlBodyIsLTRDirection;
     var _htmlBodyIsLTRWritingMode;
-    
-    
+
+
     var _currentOpacity = -1;
 
     var _lastViewPortSize = {
@@ -141,7 +141,7 @@ var ReflowableView = function(options) {
     };
 
     this.setViewSettings = function(settings) {
-        
+
         _viewSettings = settings;
 
         _paginationInfo.columnGap = settings.columnGap;
@@ -149,7 +149,7 @@ var ReflowableView = function(options) {
 
         updateHtmlFontSize();
         updateColumnGap();
-        
+
         updateViewportSize();
         updatePagination();
     };
@@ -195,7 +195,7 @@ var ReflowableView = function(options) {
             self.onContentDocumentLoadStart(spineItem);
 
             _$iframe.css("opacity", "0.01");
-            
+
             _iframeLoader.loadIframe(_$iframe[0], src, onIFrameLoad, self, {spineItem : spineItem});
         }
     }
@@ -254,9 +254,9 @@ var ReflowableView = function(options) {
         _htmlBodyIsVerticalWritingMode = false;
         _htmlBodyIsLTRDirection = true;
         _htmlBodyIsLTRWritingMode = undefined;
-        
+
         var win = _$iframe[0].contentDocument.defaultView || _$iframe[0].contentWindow;
-        
+
         //Helpers.isIframeAlive
         var htmlBodyComputedStyle = win.getComputedStyle(_$htmlBody[0], null);
         if (htmlBodyComputedStyle)
@@ -276,7 +276,7 @@ var ReflowableView = function(options) {
             if (writingMode)
             {
                 _htmlBodyIsLTRWritingMode = writingMode.indexOf("-lr") >= 0; // || writingMode.indexOf("horizontal-") >= 0; we need explicit!
-            
+
                 if (writingMode.indexOf("vertical") >= 0 || writingMode.indexOf("tb-") >= 0 || writingMode.indexOf("bt-") >= 0)
                 {
                     _htmlBodyIsVerticalWritingMode = true;
@@ -299,12 +299,12 @@ var ReflowableView = function(options) {
             _htmlBodyIsLTRDirection = false;
             _htmlBodyIsLTRWritingMode = false;
         }
-        
+
         _paginationInfo.isVerticalWritingMode = _htmlBodyIsVerticalWritingMode;
 
         updateViewportSize();
         _$epubHtml.css("height", _lastViewPortSize.height + "px");
-        
+
         _$epubHtml.css("position", "relative");
         _$epubHtml.css("margin", "0");
         _$epubHtml.css("padding", "0");
@@ -321,7 +321,7 @@ var ReflowableView = function(options) {
         // _$epubHtml.css("background-color", '#b0c4de');
         //
         // ////
-        
+
         self.applyBookStyles();
         resizeImages();
 
@@ -419,7 +419,7 @@ var ReflowableView = function(options) {
         else {
             console.log('Illegal pageIndex value: ', pageIndex, 'column count is ', _paginationInfo.columnCount);
         }
-        
+
         return false;
     };
 
@@ -464,7 +464,7 @@ var ReflowableView = function(options) {
 
     function onPaginationChanged(initiator, paginationRequest_spineItem, paginationRequest_elementId) {
         _paginationInfo.pageOffset = (_paginationInfo.columnWidth + _paginationInfo.columnGap) * _paginationInfo.visibleColumnCount * _paginationInfo.currentSpreadIndex;
-        
+
         redraw();
 
         self.onCurrentViewPaginationChanged(initiator, paginationRequest_spineItem, paginationRequest_elementId);
@@ -520,12 +520,12 @@ var ReflowableView = function(options) {
         // At 100% font-size = 16px (on HTML, not body or descendant markup!)
         var MAXW = 550; //TODO user/vendor-configurable?
         var MINW = 400;
-        
+
         var isDoublePageSyntheticSpread = Helpers.deduceSyntheticSpread(_$viewport, _currentSpineItem, _viewSettings);
-        
+
         var forced = (isDoublePageSyntheticSpread === false) || (isDoublePageSyntheticSpread === true);
         // excludes 0 and 1 falsy/truthy values which denote non-forced result
-        
+
 // console.debug("isDoublePageSyntheticSpread: " + isDoublePageSyntheticSpread);
 // console.debug("forced: " + forced);
 //
@@ -534,9 +534,9 @@ var ReflowableView = function(options) {
             isDoublePageSyntheticSpread = 1; // try double page, will shrink if doesn't fit
 // console.debug("TRYING SPREAD INSTEAD OF SINGLE...");
         }
-        
+
         _paginationInfo.visibleColumnCount = isDoublePageSyntheticSpread ? 2 : 1;
-   
+
         if (_htmlBodyIsVerticalWritingMode)
         {
             MAXW *= 2;
@@ -549,9 +549,9 @@ var ReflowableView = function(options) {
         if(!_$epubHtml) {
             return;
         }
-        
+
         hideBook(); // shiftBookOfScreen();
-        
+
         var borderLeft = parseInt(_$viewport.css("border-left-width"));
         var borderRight = parseInt(_$viewport.css("border-right-width"));
         var adjustedGapLeft = _paginationInfo.columnGap/2;
@@ -560,7 +560,7 @@ var ReflowableView = function(options) {
         adjustedGapRight = Math.max(0, adjustedGapRight-borderRight)
 
         var filler = 0;
-        
+
 //         var win = _$iframe[0].contentDocument.defaultView || _$iframe[0].contentWindow;
 //         var htmlBodyComputedStyle = win.getComputedStyle(_$htmlBody[0], null);
 //         if (htmlBodyComputedStyle)
@@ -576,21 +576,21 @@ var ReflowableView = function(options) {
 //             }
 // console.debug(fontSize);
 //         }
-        
+
         if (_viewSettings.fontSize)
         {
             var fontSizeAdjust = (_viewSettings.fontSize*0.8)/100;
             MAXW = Math.floor(MAXW * fontSizeAdjust);
             MINW = Math.floor(MINW * fontSizeAdjust);
         }
-        
+
         var availableWidth = _$viewport.width();
         var textWidth = availableWidth - borderLeft - borderRight - adjustedGapLeft - adjustedGapRight;
         if (isDoublePageSyntheticSpread)
         {
             textWidth = (textWidth - _paginationInfo.columnGap) * 0.5;
         }
-        
+
         if (textWidth > MAXW)
         {
 // console.debug("LIMITING WIDTH");
@@ -601,23 +601,23 @@ var ReflowableView = function(options) {
 //console.debug("REDUCING SPREAD TO SINGLE");
             isDoublePageSyntheticSpread = false;
             _paginationInfo.visibleColumnCount = 1;
-            
+
             textWidth = availableWidth - borderLeft - borderRight - adjustedGapLeft - adjustedGapRight;
             if (textWidth > MAXW)
             {
                 filler = Math.floor((textWidth - MAXW) * 0.5);
             }
         }
-        
+
         _$el.css({"left": (filler+adjustedGapLeft + "px"), "right": (filler+adjustedGapRight + "px")});
         updateViewportSize(); //_$contentFrame ==> _lastViewPortSize
 
-        
+
         _$iframe.css("width", _lastViewPortSize.width + "px");
         _$iframe.css("height", _lastViewPortSize.height + "px");
 
         _$epubHtml.css("height", _lastViewPortSize.height + "px");
-        
+
         // below min- max- are required in vertical writing mode (height is not enough, in some cases...weird!)
         _$epubHtml.css("min-height", _lastViewPortSize.height + "px");
         _$epubHtml.css("max-height", _lastViewPortSize.height + "px");
@@ -643,9 +643,9 @@ var ReflowableView = function(options) {
         }
 
         _$epubHtml.css("column-fill", "auto");
-        
+
         _$epubHtml.css({left: "0", right: "0", top: "0"});
-        
+
         Helpers.triggerLayout(_$iframe);
 
         _paginationInfo.columnCount = ((_htmlBodyIsVerticalWritingMode ? _$epubHtml[0].scrollHeight : _$epubHtml[0].scrollWidth) + _paginationInfo.columnGap) / (_paginationInfo.columnWidth + _paginationInfo.columnGap);
@@ -660,7 +660,7 @@ var ReflowableView = function(options) {
             console.debug("ADJUST COLUMN");
             console.log(_paginationInfo.columnWidth);
             console.log(colWidthCheck);
-            
+
             _paginationInfo.columnWidth = colWidthCheck;
         }
 
@@ -678,7 +678,7 @@ var ReflowableView = function(options) {
         else {
 
             //we get here on resizing the viewport
-            
+
             onPaginationChanged(self); // => redraw() => showBook(), so the trick below is not needed
 
             // //We do this to force re-rendering of the document in the iframe.
@@ -707,7 +707,7 @@ var ReflowableView = function(options) {
     {
         if (!_$epubHtml) return;
         if (_currentOpacity != -1) return; // already hidden
-        
+
         _currentOpacity = _$epubHtml.css('opacity');
         _$epubHtml.css('opacity', "0");
     }
@@ -855,12 +855,12 @@ var ReflowableView = function(options) {
         var visibleContentOffsets = getVisibleContentOffsets();
         return _navigationLogic.getFirstVisibleMediaOverlayElement(visibleContentOffsets);
     };
-    
+
     // /**
     //  * @deprecated
     //  */
     // this.getVisibleMediaOverlayElements = function() {
-    // 
+    //
     //     var visibleContentOffsets = getVisibleContentOffsets();
     //     return _navigationLogic.getVisibleMediaOverlayElements(visibleContentOffsets);
     // };
@@ -888,7 +888,7 @@ var ReflowableView = function(options) {
         {
             id = element.getAttribute("id");
         }
-        
+
         if (id)
         {
             openPageRequest.setElementId(id);

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -581,12 +581,12 @@ var ReflowableView = function(options, reader){
 // console.debug(fontSize);
 //         }
         
-        if (_viewSettings.fontSize)
-        {
-            var fontSizeAdjust = (_viewSettings.fontSize*0.8)/100;
-            MAXW = Math.floor(MAXW * fontSizeAdjust);
-            MINW = Math.floor(MINW * fontSizeAdjust);
-        }
+        // // if (_viewSettings.fontSize)
+        // {
+        //     var fontSizeAdjust = (_viewSettings.fontSize*0.8)/100;
+        //     MAXW = Math.floor(MAXW * fontSizeAdjust);
+        //     MINW = Math.floor(MINW * fontSizeAdjust);
+        // }
         
         var availableWidth = _$viewport.width();
         var textWidth = availableWidth - borderLeft - borderRight - adjustedGapLeft - adjustedGapRight;

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -580,7 +580,7 @@ var ReflowableView = function(options) {
 // console.debug(fontSize);
 //         }
         
-        // if (_viewSettings.fontSize)
+        if (_viewSettings.fontSize)
         {
             var fontSizeAdjust = (_viewSettings.fontSize*0.8)/100;
             MAXW = Math.floor(MAXW * fontSizeAdjust);

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -92,7 +92,7 @@ var ReflowableView = function(options) {
         _$el = $(template);
         _$viewport.append(_$el);
 
-        var settings = options.settings;
+        var settings = options.viewSettings;
         if (!settings || typeof settings.enableGPUHardwareAccelerationCSS3D === "undefined")
         {
             //defaults

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -48,6 +48,7 @@ var ReflowableView = function(options, reader){
     var _userStyles = options.userStyles;
     var _bookStyles = options.bookStyles;
     var _iframeLoader = options.iframeLoader;
+    var _cachedView = options.cachedView;
     
     var _currentSpineItem;
     var _isWaitingFrameRender = false;    
@@ -328,6 +329,7 @@ var ReflowableView = function(options, reader){
 
         updateHtmlFontSize();
         updateColumnGap();
+        self.applyStyles();
 
 
         self.applyStyles();
@@ -370,14 +372,14 @@ var ReflowableView = function(options, reader){
 
         if(_isWaitingFrameRender) {
             _deferredPageRequest = pageRequest;
-            return;
+            return false;
         }
 
         // if no spine item specified we are talking about current spine item
         if(pageRequest.spineItem && pageRequest.spineItem != _currentSpineItem) {
             _deferredPageRequest = pageRequest;
             loadSpineItem(pageRequest.spineItem);
-            return;
+            return true;
         }
 
         var pageIndex = undefined;
@@ -417,10 +419,13 @@ var ReflowableView = function(options, reader){
         if(pageIndex >= 0 && pageIndex < _paginationInfo.columnCount) {
             _paginationInfo.currentSpreadIndex = Math.floor(pageIndex / _paginationInfo.visibleColumnCount) ;
             onPaginationChanged(pageRequest.initiator, pageRequest.spineItem, pageRequest.elementId);
+            return true;
         }
         else {
             console.log('Illegal pageIndex value: ', pageIndex, 'column count is ', _paginationInfo.columnCount);
         }
+        
+        return false;
     };
 
     function redraw() {
@@ -439,12 +444,19 @@ var ReflowableView = function(options, reader){
             _$epubHtml.css("right", !ltr ? offsetVal : "");
         }
 
-        showBook(); // as it's no longer hidden by shifting the position
+        if (!_cachedView) {
+            showBook(); // as it's no longer hidden by shifting the position
+        }
     }
 
     function updateViewportSize() {
 
         var newWidth = _$contentFrame.width();
+
+        // Ensure that the new viewport width is always even numbered
+        // this is to prevent a rendering inconsistency between browsers when odd-numbered bounds are used for CSS columns
+        newWidth -= newWidth % 2;
+
         var newHeight = _$contentFrame.height();
 
         if(_lastViewPortSize.width !== newWidth || _lastViewPortSize.height !== newHeight){
@@ -458,7 +470,6 @@ var ReflowableView = function(options, reader){
     }
 
     function onPaginationChanged(initiator, paginationRequest_spineItem, paginationRequest_elementId) {
-
         _paginationInfo.pageOffset = (_paginationInfo.columnWidth + _paginationInfo.columnGap) * _paginationInfo.visibleColumnCount * _paginationInfo.currentSpreadIndex;
         
         redraw();
@@ -888,6 +899,26 @@ var ReflowableView = function(options, reader){
 
         self.openPage(openPageRequest);
     }
+
+    this.getLoadedContentFrames = function () {
+        return [{spineItem: _currentSpineItem, $iframe: _$iframe}];
+    };
+
+    this.hide = function() {
+        _$el.hide();
+    };
+
+    this.show = function() {
+        _$el.show();
+        showBook();
+    };
+
+    this.setCached = function(isCached) {
+        _cachedView = isCached;
+    };
+
+
+
 
 };
     return ReflowableView;

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -125,7 +125,20 @@ var ReflowableView = function(options) {
     this.remove = function() {
 
         //$(window).off("resize.ReadiumSDK.reflowableView");
+        _$htmlBody.remove();
+        _$htmlBody = null;
+
+        _$epubHtml.remove();
+        _$epubHtml = null;
+
+        _$iframe.remove();
+        _$iframe = null;
+
+        _$contentFrame.remove();
+        _$contentFrame = null;
+
         _$el.remove();
+        _$el = null;
 
     };
 

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -608,7 +608,7 @@ var ScrollView = function (options, isContinuousScroll, reader) {
 
     function removePageView(pageView) {
 
-        pageView.element().remove();
+        pageView.remove();
 
     }
 
@@ -623,7 +623,13 @@ var ScrollView = function (options, isContinuousScroll, reader) {
     }
 
     this.remove = function () {
+        removeLoadedItems();
+
+        _$contentFrame.remove();
+        _$contentFrame = null;
+
         _$el.remove();
+        _$el = null;
     };
 
     this.onViewportResize = function () {


### PR DESCRIPTION
# ~~**_This is a work in progress. Please don't merge.**_~~ please see updates further down.

I'm going to be away on leave until May, so this is a placeholder for tracking this feature.
# Summary

The intent of the prefetching feature is to allow seamless inter-spine transitions. In cloud reader configuration, spines are fetched "just in time", right when the reader is about to display them. Depending on content size and network throughput this introduces a delay that is interrupts the reading flow. This feature aims to solve this problem by intelligently prefetching necessary spine items and rendering them when requested by the reader.
# Current status

As of Friday, February 27, 2015, this pull request contains a proof of contept implementation for reflowable and fixed layout views. Reflowable views are prefetched and rendered correctly in the background. Fixed layout views are working, but not as well as reflowable views. There's a noticeable delay when fixed layout views are displayed, it probably means that the fixed layouts views haven't completed full rendering.
# Next steps
1. Refactor code. _reader_view_ doesnt necessarily need to know about anything caching related.
2. Refactor _one_page_view_ to support correct rendering order so that when the iframe is shown everything is rendered.
3. Come up with a caching strategy. Currently spines persist forever.
4. Determine how prefetching interacts with other Readium features. Since the spine is essentially loaded but not displayed does that mean that Media overlays will start playing automatically?
5. Interaction with other types of views (continuous)?
