### PR TITLE
CSS column count/width fix for two-page synthetic spread layout (fixes Firefox video flickering, and native WebView touch event support)

### DIFF
--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -618,28 +618,21 @@ ReadiumSDK.Views.ReflowableView = function(options, reader){
         _$htmlBody.css('margin', 0);
         _$htmlBody.css('padding', 0);
 
-        var spacing = 0;
-        try
-        {
-            spacing = parseInt(_$htmlBody.css('padding-top')) + parseInt(_$htmlBody.css('border-top-width')) + parseInt(_$htmlBody.css('border-bottom-width'));
-        }
-        catch(err)
-        {
-            
-        }
-        // Needed for Firefox, otherwise content shrinks vertically, resulting in scrollWidth accomodating more columns than necessary
-        //_$htmlBody.css("min-height", _lastViewPortSize.height-spacing-9 + "px");
-        _$htmlBody.css("min-height", "50%");
-        _$htmlBody.css("max-height", _lastViewPortSize.height-spacing + "px");
-
         _paginationInfo.rightToLeft = _spine.isRightToLeft();
 
         _paginationInfo.columnWidth = Math.round(((_htmlBodyIsVerticalWritingMode ? _lastViewPortSize.height : _lastViewPortSize.width) - _paginationInfo.columnGap * (_paginationInfo.visibleColumnCount - 1)) / _paginationInfo.visibleColumnCount);
 
-        _$epubHtml.css("width", (_htmlBodyIsVerticalWritingMode ? _lastViewPortSize.width : _paginationInfo.columnWidth) + "px");
+        var useColumnCountNotWidth = _paginationInfo.visibleColumnCount > 1; // column-count == 1 does not work in Chrome, and is not needed anyway (HTML width is full viewport width, no Firefox video flickering)
+        if (useColumnCountNotWidth) {
+            _$epubHtml.css("width", _lastViewPortSize.width + "px");
+            _$epubHtml.css("column-count", _paginationInfo.visibleColumnCount);
+        } else {
+            _$epubHtml.css("width", (_htmlBodyIsVerticalWritingMode ? _lastViewPortSize.width : _paginationInfo.columnWidth) + "px");
+            _$epubHtml.css("column-width", _paginationInfo.columnWidth + "px");
+        }
 
-        _$epubHtml.css("column-width", _paginationInfo.columnWidth + "px");
-
+        _$epubHtml.css("column-fill", "auto");
+        
         _$epubHtml.css({left: "0", right: "0", top: "0"});
         
         ReadiumSDK.Helpers.triggerLayout(_$iframe);


### PR DESCRIPTION
using column-fill:auto to prevent Firefox from automatically balancing content (which means the height hack isn't needed anymore), more importantly: column-count is used for two-page synthetic spreads, but column-width still used for single-page layout (for some weird CSS reason, we need this discrepancy in Chrome)