### PR TITLE
Resize images to fit a reflowable column or scrollable page view.

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -582,6 +582,54 @@ ReadiumSDK.Helpers.extendedThrottle = function (startCb, tickCb, endCb, tickRate
 };
 
 
+ReadiumSDK.Helpers.fitImages = function ($html, options) {
+    if(!$html) {
+        return;
+    }
+
+    options = options || {};
+
+    var $elem;
+    var height;
+    var width;
+    var $body = $('body', $html);
+    //maxHeight is (html el height) - (body el padding+margin+border)
+    //we add 3 to the maxHeight as a buffer, this fixes a strange scaling issue on IE11
+    // if we set max-width/max-height to 100% columnizing engine chops images embedded in the text
+    // (but not if we set it to 99-98%) go figure.
+    var maxDimensions = {
+        maxHeight: $html.height() - ($body.outerHeight(true) - $body.height() + Math.floor($html.height() * 0.02)),
+        maxWidth: ($body[0].getClientRects()[0] ? $body[0].getClientRects()[0].width : $html.width()) - Math.floor($html.width() * 0.02)
+    };
+
+    $('img, svg', $html).each(function(){
+
+        $elem = $(this);
+
+        if (options.doNotChangeWidth) {
+            delete maxDimensions.maxWidth;
+        }
+        if (options.doNotChangeHeight) {
+            delete maxDimensions.maxHeight;
+        }
+
+        $elem.css(maxDimensions);
+
+        var ratiosUnbalanced = false;
+        if ($elem[0].tagName.toLowerCase() === "img") {
+            ratiosUnbalanced =
+                (($elem[0].naturalWidth / $elem[0].naturalHeight) * 10 | 0) !==
+                (($elem[0].clientWidth / $elem[0].clientHeight) * 10 | 0);
+        }
+        if (!$elem.css('height') || ratiosUnbalanced) {
+            $elem.css('height', 'auto');
+        }
+        if (!$elem.css('width') || ratiosUnbalanced) {
+            $elem.css('width', 'auto');
+        }
+    });
+};
+
 //TODO: consider using CSSOM escape() or polyfill
 //https://github.com/mathiasbynens/CSS.escape/blob/master/css.escape.js
 //http://mathiasbynens.be/notes/css-escapes

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -950,6 +950,13 @@ ReadiumSDK.Views.OnePageView = function(options, classes, enableBookStyleOverrid
             return _$iframe.offset();
         }
         return undefined;
+    };
+
+    /**
+     * @private
+     */
+    this._fitImages = function (options) {
+        return ReadiumSDK.Helpers.fitImages(_$epubHtml, options);
     }
 };
 

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -318,7 +318,7 @@ ReadiumSDK.Views.ReflowableView = function(options, reader){
         // ////
         
         self.applyBookStyles();
-        resizeImages();
+        fitImages();
 
         updateHtmlFontSize();
         updateColumnGap();
@@ -456,6 +456,9 @@ ReadiumSDK.Views.ReflowableView = function(options, reader){
         _paginationInfo.pageOffset = (_paginationInfo.columnWidth + _paginationInfo.columnGap) * _paginationInfo.visibleColumnCount * _paginationInfo.currentSpreadIndex;
         
         redraw();
+        ReadiumSDK.Helpers.triggerLayout(_$iframe);
+        fitImages();
+
         self.trigger(ReadiumSDK.InternalEvents.CURRENT_VIEW_PAGINATION_CHANGED, { paginationInfo: self.getPaginationInfo(), initiator: initiator, spineItem: paginationRequest_spineItem, elementId: paginationRequest_elementId } );
     }
 
@@ -750,35 +753,8 @@ ReadiumSDK.Views.ReflowableView = function(options, reader){
     }
 
     //we need this styles for css columnizer not to chop big images
-    function resizeImages() {
-
-        if(!_$epubHtml) {
-            return;
-        }
-
-        var $elem;
-        var height;
-        var width;
-
-        $('img, svg', _$epubHtml).each(function(){
-
-            $elem = $(this);
-
-            // if we set max-width/max-height to 100% columnizing engine chops images embedded in the text
-            // (but not if we set it to 99-98%) go figure.
-            // TODO: CSS min-w/h is content-box, not border-box (does not take into account padding + border)? => images may still overrun?
-            $elem.css('max-width', '98%');
-            $elem.css('max-height', '98%');
-
-            if(!$elem.css('height')) {
-                $elem.css('height', 'auto');
-            }
-
-            if(!$elem.css('width')) {
-                $elem.css('width', 'auto');
-            }
-
-        });
+    function fitImages() {
+        return ReadiumSDK.Helpers.fitImages(_$epubHtml);
     }
 
     this.bookmarkCurrentPage = function() {

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -750,6 +750,8 @@ ReadiumSDK.Views.ScrollView = function(options, isContinuousScroll, reader){
 
     function onPageViewLoaded(pageView, success, $iframe, spineItem, isNewlyLoaded, context) {
 
+        fitImages(pageView);
+
         if(success && isNewlyLoaded) {
             self.trigger(ReadiumSDK.Events.CONTENT_DOCUMENT_LOADED, $iframe, spineItem);
         }
@@ -976,6 +978,10 @@ ReadiumSDK.Views.ScrollView = function(options, isContinuousScroll, reader){
     }
 
     function onPaginationChanged(initiator, paginationRequest_spineItem, paginationRequest_elementId) {
+        var visibleViews = getVisiblePageViews();
+        _.each(visibleViews, function (view) {
+            fitImages(view);
+        });
         self.trigger(ReadiumSDK.InternalEvents.CURRENT_VIEW_PAGINATION_CHANGED, { paginationInfo: self.getPaginationInfo(), initiator: initiator, spineItem: paginationRequest_spineItem, elementId: paginationRequest_elementId } );
     }
 
@@ -1366,6 +1372,10 @@ ReadiumSDK.Views.ScrollView = function(options, isContinuousScroll, reader){
             self.openPage(openPageRequest);
         }
 
+    };
+
+    function fitImages(pageView) {
+        pageView._fitImages({doNotChangeHeight: true});
     }
 
 };


### PR DESCRIPTION
This adds a new approach for resizing images to fit a reflowable column or scrollable page view.
- It now more actively changes the max-width, max-height values for images, before it would just run once when the iframe doc loaded. Now it runs at every pagination change.
- max-height and max-width now have calculated values and are no longer percentage based.
- For scrollable docs the max-height value is not modified.
- It now tries to preserve the original aspect ratio of the resized images.

This attempts to fix the following issues:
- https://github.com/readium/readium-shared-js/issues/144
- https://github.com/readium/readium-shared-js/issues/138
- https://github.com/readium/readium-shared-js/issues/153
- https://github.com/readium/readium-shared-js/issues/88
- https://github.com/readium/readium-shared-js/issues/64