### PR TITLE
Iframe size calculation

### DIFF
--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -512,7 +512,7 @@ ReadiumSDK.Views.OnePageView = function(options, classes, enableBookStyleOverrid
             var win = _$iframe[0].contentWindow;
             var doc = _$iframe[0].contentDocument;
             
-            var height = Math.round(parseFloat(win.getComputedStyle(doc.documentElement).height)); //body can be shorter!
+            var height = Math.round($(doc).outerHeight()); //body can be shorter!
             return height;
         }
         else if (_$epubHtml)

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -371,7 +371,7 @@ ReadiumSDK.Views.ScrollView = function(options, isContinuousScroll, reader){
                         
                         var iframeHeight = parseInt(Math.round(parseFloat(window.getComputedStyle(iframe).height)));
                     
-                        var docHeight = parseInt(Math.round(parseFloat(win.getComputedStyle(doc.documentElement).height))); //body can be shorter!
+                        var docHeight = Math.round($(doc).outerHeight()); //body can be shorter!
                         
                         if (previousPolledContentHeight !== docHeight)
                         {
@@ -406,7 +406,7 @@ ReadiumSDK.Views.ScrollView = function(options, isContinuousScroll, reader){
                                 var win = iframe.contentWindow;
                                 var doc = iframe.contentDocument;
                                 
-                                var docHeightAfter = parseInt(Math.round(parseFloat(win.getComputedStyle(doc.documentElement).height))); //body can be shorter!
+                                var docHeightAfter = Math.round($(doc).outerHeight()); //body can be shorter!
                                 var iframeHeightAfter = parseInt(Math.round(parseFloat(window.getComputedStyle(iframe).height)));
 
                                 var newdiff = iframeHeightAfter-docHeightAfter;


### PR DESCRIPTION
In getContentDocHeight(), it is the documentElement's inner height that is retrieved. This makes the iframe too small if there is padding on the html-element in the pub.

We're currently on a project where we needed to add padding in the iframe, and we ran into the problem of the iframe not sizing up correctly. We've used jquery's outerHeight() to fix it. Are we onto something? Help is much appreciated.

Einar
