### PR TITLE
Improve switch element query and namespace check

### DIFF
--- a/js/models/switches.js
+++ b/js/models/switches.js
@@ -37,9 +37,6 @@ ReadiumSDK.Models.Switches = function() {
 // cases that are not supported
 ReadiumSDK.Models.Switches.apply = function(dom) {
 
-
-    // helper method, returns true if a given case node
-    // is supported, false otherwise
     function isSupported(caseNode) {
 
         var ns = caseNode.attributes["required-namespace"];
@@ -52,29 +49,37 @@ ReadiumSDK.Models.Switches.apply = function(dom) {
         // all the xmlns that readium is known to support
         // TODO this is going to require maintenance
         var supportedNamespaces = ["http://www.w3.org/1998/Math/MathML"];
-        return _.include(supportedNamespaces, ns);
+        return _.include(supportedNamespaces, ns.value);
     }
 
-    $('switch', dom).each( function() {
+    var getQuery = window.navigator.userAgent.indexOf("Trident") > 0
+        ? function (elementName) { return 'epub\\:' + elementName; }
+        : function (elementName) { return elementName; };
+
+    _.each(dom.querySelectorAll(getQuery('switch')), function(switchNode) {
 
         // keep track of whether or now we found one
         var found = false;
 
-        $('case', this).each(function() {
+        _.each(switchNode.querySelectorAll(getQuery('case')), function(caseNode) {
 
-            if( !found && isSupported(this) ) {
+            if( !found && isSupported(caseNode) ) {
                 found = true; // we found the node, don't remove it
             }
             else {
-                $(this).remove(); // remove the node from the dom
-//                    $(this).prop("hidden", true);
+                $(caseNode).remove(); // remove the node from the dom
             }
+
         });
 
-        if(found) {
+        if (found) {
+
             // if we found a supported case, remove the default
-            $('default', this).remove();
-//                $('default', this).prop("hidden", true);
+            _.each(switchNode.querySelectorAll(getQuery('default')), function(defaultNode) {
+                $(defaultNode).remove();
+            });
+
         }
-    })
+
+    });
 };

--- a/js/models/switches.js
+++ b/js/models/switches.js
@@ -52,7 +52,7 @@ ReadiumSDK.Models.Switches.apply = function(dom) {
         return _.include(supportedNamespaces, ns.value);
     }
 
-    var getQuery = window.navigator.userAgent.indexOf("Trident") > 0
+    var getQuery = ((window.navigator.userAgent.indexOf("Trident") > 0) || (window.navigator.userAgent.indexOf("Edge") > 0))
         ? function (elementName) { return 'epub\\:' + elementName; }
         : function (elementName) { return elementName; };
 


### PR DESCRIPTION
Improve `ReadiumSDK.Models.Switches.apply` to correct the issue described in [readium/readium-js-viewer#306](https://github.com/readium/readium-js-viewer/issues/306) / [readium/readium-shared-j#117](https://github.com/readium/readium-shared-js/issues/171)