### PR TITLE
Produce Maven packages for shared Javascript components

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,29 @@ For more complex build processes, Grunt / Gulp can be used, but these build syst
 
 Downside: DO NOT invoke `npm init` or `npm install --save` `--save-dev` `--save-optional`,
 as this would overwrite / update the JSON, not the master CSON!
+
+## Maven Package
+
+Once the JS components have been bundled with the `npm build` commands
+shown above, a Maven package can be produced containing the relevant
+resources. This can then be referenced from Android applications as
+a standard library dependency, instead of having to import the sources
+directly into the project as a `git submodule`.
+
+To create a package:
+
+```bash
+$ mvn clean package
+```
+
+To reference the package from an Android application (in Maven
+dependency syntax):
+
+```
+<dependency>
+  <groupId>org.readium</groupId>
+  <artifactId>readium-shared-js</artifactId>
+  <version>0.20.0</version>
+</dependency>
+```
+

--- a/README.md
+++ b/README.md
@@ -217,7 +217,8 @@ To create a package:
 $ mvn clean package
 ```
 
-To reference the package from an Android application (in Maven
+After the package has been deployed to a repository with `mvn deploy`,
+the package can be referenced from an Android application with (in Maven
 dependency syntax):
 
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.readium</groupId>
+  <artifactId>readium-shared-js</artifactId>
+  <version>0.20.0</version>
+
+  <packaging>jar</packaging>
+  <description>Readium SDK (Shared JavaScript components)</description>
+  <url>https://github.com/readium/readium-sdk</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <prerequisites>
+    <maven>3.2.1</maven>
+  </prerequisites>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.6.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.7</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.4</version>
+        </plugin>
+
+        <!-- Produce custom manifest in jar files -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.6</version>
+          <configuration>
+            <archive>
+              <manifestEntries>
+                <Specification-Title>${project.name}</Specification-Title>
+                <Specification-Version>${project.version}</Specification-Version>
+                <Specification-Vendor>Readium Foundation</Specification-Vendor>
+                <Implementation-Title>${project.name}</Implementation-Title>
+                <Implementation-Version>${project.version}</Implementation-Version>
+                <Implementation-Vendor>Readium Foundation</Implementation-Vendor>
+                <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+                <Sealed>true</Sealed>
+              </manifestEntries>
+            </archive>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+    <!-- Pack all resources into the package -->
+    <resources>
+      <resource>
+        <directory>build-output/_single-bundle</directory>
+        <includes>
+          <include>readium-shared-js_all.js</include>
+          <include>readium-shared-js_all.js.bundles.js</include>
+          <include>readium-shared-js_all.js.map</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>build-output/css</directory>
+        <includes>
+          <include>sdk.css</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <packaging>jar</packaging>
   <description>Readium SDK (Shared JavaScript components)</description>
-  <url>https://github.com/readium/readium-sdk</url>
+  <url>https://github.com/readium/readium-shared-js</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This change simply adds a Maven POM file that will produce a standard Java jar file that can be deployed to any Maven repository. This allows anyone using Maven (or a build system that uses Maven packages such as Gradle) to add the `readium-shared-js` components to their application without having to import any sources directly, or use git submodules.

The change is entirely opt-in: If you don't run Maven, you won't see anything new.