### PR TITLE
refactor: Changed from _.extend to $.extend

### DIFF
--- a/js/globals.js
+++ b/js/globals.js
@@ -25,7 +25,7 @@
 //  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
-define(['underscore','eventEmitter'], function(_, EventEmitter) {
+define(['jquery','eventEmitter'], function($, EventEmitter) {
 /**
  * Top level ReadiumSDK namespace
  * @namespace
@@ -121,7 +121,7 @@ var Globals = {
     }
 
 };
-_.extend(Globals, new EventEmitter());
+$.extend(Globals, new EventEmitter());
 
 return Globals;
 

--- a/js/globalsSetup.js
+++ b/js/globalsSetup.js
@@ -12,13 +12,13 @@
 //  prior written permission.
 
 //'text!empty:'
-define(['console_shim', 'eventEmitter', 'URIjs', 'readium_cfi_js', 'readium_js_plugins', './globals'], function (console_shim, EventEmitter, URI, epubCfi, PluginsController, Globals) {
+define(['jquery', 'console_shim', 'eventEmitter', 'URIjs', 'readium_cfi_js', 'readium_js_plugins', './globals'], function ($, console_shim, EventEmitter, URI, epubCfi, PluginsController, Globals) {
 
     console.log("Globals...");
 
     if (window["ReadiumSDK"]) {
         console.log("ReadiumSDK extend.");
-        _.extend(Globals, window.ReadiumSDK);
+        $.extend(Globals, window.ReadiumSDK);
     } else {
         console.log("ReadiumSDK set.");
     }

--- a/js/plugins_controller.js
+++ b/js/plugins_controller.js
@@ -79,7 +79,7 @@ define(["jquery", "underscore", "eventEmitter"], function ($, _, EventEmitter) {
                     plugin.initialized = true;
                     try {
                         var pluginContext = {};
-                        _.extend(pluginContext, new EventEmitter());
+                        $.extend(pluginContext, new EventEmitter());
 
                         initFunc.call(pluginContext, api.instance);
                         plugin.supported = true;

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -35,7 +35,7 @@ define (["jquery", "underscore", "eventEmitter", "../models/bookmark_data", "../
  */
 var FixedView = function(options, reader){
 
-    _.extend(this, new EventEmitter());
+    $.extend(this, new EventEmitter());
 
     var self = this;
 

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -37,7 +37,7 @@ define(["jquery", "underscore", "eventEmitter", "./cfi_navigation_logic", "../he
  */
 var OnePageView = function (options, classes, enableBookStyleOverrides, reader) {
 
-    _.extend(this, new EventEmitter());
+    $.extend(this, new EventEmitter());
 
     var self = this;
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -48,7 +48,7 @@ define(["jquery", "underscore", "eventEmitter", "./fixed_view", "../helpers", ".
  */
 var ReaderView = function (options) {
 
-    _.extend(this, new EventEmitter());
+    $.extend(this, new EventEmitter());
 
     var self = this;
     var _currentView = undefined;

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -39,7 +39,7 @@ define(["jquery", "underscore", "eventEmitter", "../models/bookmark_data", "./cf
  */
 var ReflowableView = function(options, reader){
 
-    _.extend(this, new EventEmitter());
+    $.extend(this, new EventEmitter());
 
     var self = this;
     

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -38,7 +38,7 @@ var ScrollView = function (options, isContinuousScroll, reader) {
 
     var _DEBUG = false;
 
-    _.extend(this, new EventEmitter());
+    $.extend(this, new EventEmitter());
 
     var SCROLL_MARGIN_TO_SHOW_LAST_VISBLE_LINE = 5;
     var ITEM_LOAD_SCROLL_BUFFER = 2000;

--- a/plugins/annotations/annotations_manager.js
+++ b/plugins/annotations/annotations_manager.js
@@ -126,7 +126,7 @@ var AnnotationsManager = function (proxyObj, options) {
         console.warn("WARNING! Annotations CSS not supplied. Highlighting is not going to work.");
     }
 
-    _.extend(this, new EventEmitter());
+    $.extend(this, new EventEmitter());
 
     // we want to bubble up all of the events that annotations module may trigger up.
     // this.on("all", function() {


### PR DESCRIPTION
* Underscore and jQuery copy all properties and prototypes whereas
  lodash only copies enumerables. In order to use the global lodash
  the jQuery.extend was used.