### PR TITLE
Feature/non linear spine items

### DIFF
--- a/js/models/current_pages_info.js
+++ b/js/models/current_pages_info.js
@@ -64,15 +64,11 @@ var CurrentPagesInfo = function(spine, isFixedLayout) {
 
         var lastOpenPage = this.openPages[this.openPages.length - 1];
 
-        // TODO: handling of non-linear spine items ("ancillary" documents), allowing page turn within the reflowable XHTML, but preventing previous/next access to sibling spine items. Also needs "go back" feature to navigate to source hyperlink location that led to the non-linear document.
-        // See https://github.com/readium/readium-shared-js/issues/26
-
-        // Removed, needs to be implemented properly as per above.
-        // See https://github.com/readium/readium-shared-js/issues/108
-        // if(!spine.isValidLinearItem(lastOpenPage.spineItemIndex))
-        //     return false;
-
-        return lastOpenPage.spineItemIndex < spine.last().index || lastOpenPage.spineItemPageIndex < lastOpenPage.spineItemPageCount - 1;
+        if(spine.isValidLinearItem(lastOpenPage.spineItemIndex))
+            return lastOpenPage.spineItemIndex < spine.last().index || lastOpenPage.spineItemPageIndex < lastOpenPage.spineItemPageCount - 1;
+        else
+            return lastOpenPage.spineItemPageIndex < lastOpenPage.spineItemPageCount - 1;
+            
     };
 
     this.canGoPrev = function() {
@@ -82,15 +78,10 @@ var CurrentPagesInfo = function(spine, isFixedLayout) {
 
         var firstOpenPage = this.openPages[0];
 
-        // TODO: handling of non-linear spine items ("ancillary" documents), allowing page turn within the reflowable XHTML, but preventing previous/next access to sibling spine items. Also needs "go back" feature to navigate to source hyperlink location that led to the non-linear document.
-        // See https://github.com/readium/readium-shared-js/issues/26
-
-        // Removed, needs to be implemented properly as per above.
-        // //https://github.com/readium/readium-shared-js/issues/108
-        // if(!spine.isValidLinearItem(firstOpenPage.spineItemIndex))
-        //     return false;
-
-        return spine.first().index < firstOpenPage.spineItemIndex || 0 < firstOpenPage.spineItemPageIndex;
+        if(spine.isValidLinearItem(firstOpenPage.spineItemIndex))
+            return spine.first().index < firstOpenPage.spineItemIndex || 0 < firstOpenPage.spineItemPageIndex;
+        else
+            return 0 < firstOpenPage.spineItemPageIndex;
     };
 
     this.sort = function() {

--- a/js/models/navigation_history.js
+++ b/js/models/navigation_history.js
@@ -115,6 +115,10 @@ var NavigationHistory = function (readerview) {
         
         return bookMark;
     };
+        
+    this.canPop = function() {
+        return _breadcrumb.length > 0;
+    };
     
     this.skipNext = function() {
         if (_DEBUG) {

--- a/js/models/navigation_history.js
+++ b/js/models/navigation_history.js
@@ -53,6 +53,23 @@ var NavigationHistory = function (readerview) {
     };
     this.flush();
 
+    this.containsLinear = function() {
+        
+        for (var i = 0; i < _breadcrumb.length; i++) {
+            var bookMark = _breadcrumb[i];
+            if (bookMark && bookMark.idref) {
+                var spineItem = readerview.spine().getItemById(bookMark.idref);
+            
+                var isLinear = spineItem && readerview.spine().isValidLinearItem(spineItem.index);
+                if (isLinear) {
+                    return true;
+                }
+            }
+        }
+        
+        return false;
+    };
+
     this.push = function (bookMark) {
         
         if (_skipNext) {

--- a/js/models/navigation_history.js
+++ b/js/models/navigation_history.js
@@ -1,0 +1,128 @@
+//  Created by Boris Schneiderman.
+// Modified by Daniel Weck
+//  Copyright (c) 2014 Readium Foundation and/or its licensees. All rights reserved.
+//  
+//  Redistribution and use in source and binary forms, with or without modification, 
+//  are permitted provided that the following conditions are met:
+//  1. Redistributions of source code must retain the above copyright notice, this 
+//  list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright notice, 
+//  this list of conditions and the following disclaimer in the documentation and/or 
+//  other materials provided with the distribution.
+//  3. Neither the name of the organization nor the names of its contributors may be 
+//  used to endorse or promote products derived from this software without specific 
+//  prior written permission.
+//  
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+//  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+//  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+//  IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+//  INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
+//  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
+//  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+//  OF THE POSSIBILITY OF SUCH DAMAGE.
+
+define([
+    //"jquery", "underscore"
+    ],
+    function (
+        //$, _
+        ) {
+
+
+var NavigationHistory = function (readerview) {
+
+    var _DEBUG = true;
+
+    var self = this;
+    
+    var _readerView = readerview;
+    
+    var _breadcrumb = [];
+    
+    var _skipNext = false;
+    
+    this.flush = function () {
+        if (_DEBUG) {
+            console.error("NavigationHistory FLUSH.");
+        }
+        
+        _breadcrumb = [];
+    };
+    this.flush();
+
+    this.push = function (bookMark) {
+        
+        if (_skipNext) {
+                
+            if (_DEBUG) {
+                console.error("NavigationHistory PUSH SKIP: ");
+                console.debug(bookMark);
+            }
+        
+            _skipNext = false;
+            return;
+        }
+        
+        if (_DEBUG) {
+            console.error("NavigationHistory PUSH: ");
+            console.debug(bookMark);
+        }
+        
+        if (_breadcrumb.length) {
+            var lastBookMark = _breadcrumb[_breadcrumb.length-1];
+            
+            var bookMark_contentCFI = bookMark.contentCFI;
+            // TODO bookmark spatial @x:y! (should be charcter offset)
+            // if (bookMark_contentCFI) {
+            //     var i = bookMark_contentCFI.lastIndexOf("@");
+            //     if (i > 1) {
+            //         bookMark_contentCFI = bookMark_contentCFI.substr(0, i);
+            //     }
+            // }
+            
+            var lastBookMark_contentCFI = lastBookMark.contentCFI;
+            // TODO bookmark spatial @x:y! (should be charcter offset)
+            // if (lastBookMark_contentCFI) {
+            //     i = lastBookMark_contentCFI.lastIndexOf("@");
+            //     if (i > 1) {
+            //         lastBookMark_contentCFI = lastBookMark_contentCFI.substr(0, i);
+            //     }
+            // }
+            
+            if (bookMark.idref == lastBookMark.idref
+                && bookMark_contentCFI == lastBookMark_contentCFI) {
+                
+                if (_DEBUG) {
+                    console.log("--- NavigationHistory skipping duplicate bookmark: " + bookMark.idref + " -- " + bookMark_contentCFI);
+                }
+                return;
+            }
+        }
+        
+        _breadcrumb.push(bookMark);
+    };
+    
+    this.pop = function () {
+        var bookMark = _breadcrumb.pop();
+        
+        if (_DEBUG) {
+            console.error("NavigationHistory POP: ");
+            console.debug(bookMark);
+        }
+        
+        return bookMark;
+    };
+    
+    this.skipNext = function() {
+        if (_DEBUG) {
+            console.error("NavigationHistory SKIP NEXT.");
+        }
+        _skipNext = true;
+    };
+};
+return NavigationHistory;
+
+});

--- a/js/models/spine.js
+++ b/js/models/spine.js
@@ -55,7 +55,7 @@ var Spine = function(epubPackage, spineDTO) {
      */
     this.package = epubPackage;
 
-    var _handleLinear = false;
+    var _handleLinear = true;
 
     this.handleLinear = function(handleLinear) {
         _handleLinear = handleLinear;

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -764,6 +764,8 @@ var ReaderView = function (options) {
                 console.log("back nav: ");
                 console.debug(bookMark);
                 
+                _navigationHistory.skipNext();
+                
                 initViewForItem(spineItem, function (isViewChanged) {
                     
                     if (!isViewChanged) {
@@ -772,12 +774,26 @@ var ReaderView = function (options) {
 
                     self.openSpineItemElementCfi(bookMark.idref, bookMark.contentCFI, self);
                 });
+                
+                return;
             }
             
-            break;
+            console.error("no valid back history?");
+            return;
         }
     };
 
+    this.navigationHistoryCanBack = function(forceLinear) {
+        
+        if (!_navigationHistory.canPop()) return false;
+            
+        if (!forceLinear) {
+            return true;
+        }
+        
+        return _navigationHistory.containsLinear();
+    };
+    
     // dir: 0 => new or same page, 1 => previous, 2 => next
     function openPage(pageRequest, dir) {
 

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -457,13 +457,15 @@ var ReflowableView = function(options, reader){
         return false;
     }
 
-    function onPaginationChanged(initiator, paginationRequest_spineItem, paginationRequest_elementId) {
+    function onPaginationChanged_(initiator, paginationRequest_spineItem, paginationRequest_elementId) {
 
         _paginationInfo.pageOffset = (_paginationInfo.columnWidth + _paginationInfo.columnGap) * _paginationInfo.visibleColumnCount * _paginationInfo.currentSpreadIndex;
         
         redraw();
+        
         self.emit(Globals.InternalEvents.CURRENT_VIEW_PAGINATION_CHANGED, { paginationInfo: self.getPaginationInfo(), initiator: initiator, spineItem: paginationRequest_spineItem, elementId: paginationRequest_elementId } );
     }
+    var onPaginationChanged = _.debounce(onPaginationChanged_, 100);
 
     this.openPagePrev = function (initiator) {
 


### PR DESCRIPTION
introduces navigation history (breadcrumb) too, as the "return to primary reading flow from ancillary document" feature is built upon the same mechanism.
Fixes:
https://github.com/readium/readium-shared-js/issues/149
https://github.com/readium/readium-shared-js/issues/26

See:
https://docs.google.com/document/d/1XY4SL0hwcr4b6XvCw8yf9tKQMnDXDnjKs_MDEzPKTHc