### PR TITLE
updateSettings showBook/hideBook css('opacity') Firefox iframe issue

### DIFF
--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -724,7 +724,10 @@ var ReflowableView = function(options, reader){
     {
         if (_currentOpacity != -1) return; // already hidden
 
-        _currentOpacity = _$epubHtml.css('opacity');
+        // css('opacity') produces invalid result in Firefox, when iframes are involved and when is called
+        // directly after set, i.e. after showBook(), see: https://github.com/jquery/jquery/issues/2622
+        //_currentOpacity = $epubHtml.css('opacity');
+        _currentOpacity = _$epubHtml[0].style.opacity;
         _$epubHtml.css('opacity', "0");
     }
 


### PR DESCRIPTION
I'm implementing text zoom in own app and call updateSettings() with changed fontSize value. I noticed, that epub disappears sometimes in Firefox (but is fine in Chrome and IE). 

Debugging reveals that epub iframe's opacity becomes "0" after updateSettings() call. 
I noticed that `showBook()` and `hideBook()` are called multiple times in reflowable_view.js (which perhaps  is separate performance/logic issue), but in Firefox it leads to more important issue: 
calling `hideBook()` with `_currentOpacity = $epubHtml.css('opacity')` after `showBook()` with `_$epubHtml.css('opacity', _currentOpacity)` stores invalid value ("0" instead of "1") in `_currentOpacity`. 
It looks like jQuery issue: https://github.com/jquery/jquery/issues/2622

In proposed fix I changed jQuery css() getter to direct `style` property access - now it works for me in Firefox too.