### PR TITLE
fix IE's script70 error

### DIFF
--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -100,15 +100,19 @@ var ScrollView = function (options, isContinuousScroll, reader) {
 
         self.applyStyles();
 
+        setupContentFrameScrollListener();
+
+        return self;
+    };
+
+    function setupContentFrameScrollListener() {
         var lazyScroll = _.debounce(onScroll, ON_SCROLL_TIME_DALAY);
 
         _$contentFrame.on('scroll', function (e) {
             lazyScroll(e);
             onScrollDirect();
         });
-
-        return self;
-    };
+    }
 
     function updateLoadedViewsTop(callback, assertScrollPosition) {
 
@@ -823,6 +827,9 @@ var ScrollView = function (options, isContinuousScroll, reader) {
 
 
     this.openPage = function (pageRequest) {
+        if (_$contentFrame) {
+            _$contentFrame.off('scroll');
+        }
 
         _stopTransientViewUpdate = true;
 
@@ -849,6 +856,7 @@ var ScrollView = function (options, isContinuousScroll, reader) {
 
                     setTimeout(function () {
                         _isLoadingNewSpineItemOnPageRequest = false;
+                        setupContentFrameScrollListener();
                     }, ON_SCROLL_TIME_DALAY + 100);
 
                     if (pageView && _deferredPageRequest) {


### PR DESCRIPTION
Whenever we scroll Readium tries to find the next visible media
overlay element to play.
The problem arises when the user changed the page and had scrolled
before. Some funny combination of things triggers the scroll handler to
run again and because it has a stale reference of the iframe's document
IE gives out with the `script70` error message.
This commit unbinds the scroll handler before that can even happen,
i.e., when we are about to open a new page and rebinds it once its done.

May fix #162.