### PR TITLE
Optimization and fixes for the highlights plugin

### DIFF
--- a/plugins/highlights/helpers.js
+++ b/plugins/highlights/helpers.js
@@ -9,9 +9,15 @@ define(function() {
             return matrix === "none" ? undefined : matrix;
         },
         getScaleFromMatrix: function(matrix) {
-            var matrixRegex = /matrix\((-?\d*\.?\d+),\s*0,\s*0,\s*(-?\d*\.?\d+),\s*0,\s*0\)/,
-                matches = matrix.match(matrixRegex);
-            return matches[1];
+            if (matrix) {
+                var matrixRegex = /matrix\((-?\d*\.?\d+),\s*0,\s*0,\s*(-?\d*\.?\d+),\s*0,\s*0\)/;
+                var matches = matrix.match(matrixRegex);
+
+                if (matches && matches.length > 0)
+                    return matches[1];
+            }
+            
+            return 1.0;
         }
     };
 

--- a/plugins/highlights/models/group.js
+++ b/plugins/highlights/models/group.js
@@ -430,12 +430,11 @@ function($, _, Class, TextLineInferrer, HighlightView, HighlightBorderView, High
             $html.on(this.getBoundHighlightContainerEvents(), that.boundHighlightCallback);
         },
 
-        resetHighlights: function(viewportElement, offsetTop, offsetLeft) {
+        resetHighlights: function(offsetTop, offsetLeft) {
             this.offsetTopAddition = offsetTop;
             this.offsetLeftAddition = offsetLeft;
             this.destroyCurrentHighlights();
             this.constructHighlightViews();
-            this.renderHighlights(viewportElement);
         },
 
         destroyCurrentHighlights: function() {
@@ -462,7 +461,11 @@ function($, _, Class, TextLineInferrer, HighlightView, HighlightBorderView, High
                 return;
             }
 
-            _.each(this.highlightViews, function(view, index) {
+            // execute the rendering on the next run loop iteration in case
+            // we create multiple highlights in batch, we don't want to
+            // do a layout for each highlight!
+            var that = this;
+            _.each(that.highlightViews, function(view, index) {
                 $(viewportElement).append(view.render());
             });
         },

--- a/plugins/highlights/models/group.js
+++ b/plugins/highlights/models/group.js
@@ -464,11 +464,7 @@ function($, _, Class, TextLineInferrer, HighlightView, HighlightBorderView, High
                 return;
             }
 
-            // execute the rendering on the next run loop iteration in case
-            // we create multiple highlights in batch, we don't want to
-            // do a layout for each highlight!
-            var that = this;
-            _.each(that.highlightViews, function(view, index) {
+            _.each(this.highlightViews, function(view, index) {
                 $(viewportElement).append(view.render());
             });
         },

--- a/plugins/highlights/models/group.js
+++ b/plugins/highlights/models/group.js
@@ -140,6 +140,9 @@ function($, _, Class, TextLineInferrer, HighlightView, HighlightBorderView, High
             var highlightStyles = this.styles;
             var cloneTextMode = highlightStyles ? highlightStyles['-rd-highlight-mode'] === 'clone-text' : false;
 
+            if (!contentDocumentFrame || !contentDocumentFrame.contentWindow)
+                return;
+
             function pushToRectTextList(range) {
                 var match,
                     rangeText = range.toString(),
@@ -374,7 +377,7 @@ function($, _, Class, TextLineInferrer, HighlightView, HighlightBorderView, High
                 var y = e.pageY;
 
                 if (e.type === 'touchend') {
-                    var lastTouch = _.last(e.changedTouches);
+                    var lastTouch = _.last(e.originalEvent.changedTouches);
                     x = lastTouch.pageX;
                     y = lastTouch.pageY;
                 }

--- a/plugins/highlights/views/view.js
+++ b/plugins/highlights/views/view.js
@@ -9,8 +9,6 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
         init: function(context, options) {
             this.context = context;
 
-            this.lengthLib = new Length(this.context.document);
-
             this.highlight = {
                 id: options.id,
                 CFI: options.CFI,
@@ -187,7 +185,7 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
                             delete copiedFirstLineStyles['text-transform'];
                             _.each(["font-size", "letter-spacing"], function(styleName) {
                                 if (copiedFirstLineStyles[styleName]) {
-                                    copiedFirstLineStyles[styleName] = that.lengthLib.toPx(data.ancestorEl, copiedFirstLineStyles[styleName]) + "px";
+                                    copiedFirstLineStyles[styleName] = that.getLengthLib().toPx(data.ancestorEl, copiedFirstLineStyles[styleName]) + "px";
                                 }
                             });
                         }
@@ -225,6 +223,16 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
                 processedElements = null;
                 computedStyles = null;
             }
+        },
+
+        getLengthLib: function() {
+            // lazy-load length lib has it takes ~300ms in some cases and we
+            // don't always need it
+            if (!this.lengthLib) {
+                this.lengthLib = new Length(this.context.document);
+            }
+
+            return this.lengthLib;
         },
 
         setCSS: function() {

--- a/plugins/highlights/views/view.js
+++ b/plugins/highlights/views/view.js
@@ -26,8 +26,13 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
         },
 
         render: function() {
+            if (this.$el) {
+                this.$el.remove();
+            }
+            
             this.$el = $(this.template, this.context.document);
             this.$el.attr('data-id', this.highlight.id);
+
             this.updateStyles();
             this.renderContent();
             return this.$el;
@@ -36,7 +41,10 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
         remove: function() {
             this.highlight = null;
             this.context = null;
-            this.$el.remove();
+
+            if (this.$el) {
+                this.$el.remove();
+            }
         },
 
 
@@ -65,12 +73,14 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
                 styles: styles
             });
 
-            // we need to fully restyle view elements
-            // remove all the "inline" styles
-            this.$el.removeAttr("style");
+            if (this.$el) {
+                // we need to fully restyle view elements
+                // remove all the "inline" styles
+                this.$el.removeAttr("style");
 
-            // remove class applied by "type"
-            this.$el.removeClass(oldType);
+                // remove class applied by "type"
+                this.$el.removeClass(oldType);
+            }
 
             this.updateStyles();
         },
@@ -236,6 +246,9 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
         },
 
         setCSS: function() {
+            if (!this.$el)
+                return;
+
             // set highlight's absolute position
             this.$el.css({
                 "position": "absolute",
@@ -255,6 +268,9 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
         },
 
         setBaseHighlight: function(removeFocus) {
+            if (!this.$el)
+                return;
+
             var type = this.highlight.type;
             this.$el.addClass(type);
             this.$el.removeClass("hover-" + type);
@@ -264,18 +280,27 @@ function($, _, Class, Length, TextLineInferrer, CopiedTextStyles) {
         },
 
         setHoverHighlight: function() {
+            if (!this.$el)
+                return;
+
             var type = this.highlight.type;
             this.$el.addClass("hover-" + type);
             this.$el.removeClass(type);
         },
 
         setFocusedHighlight: function() {
+            if (!this.$el)
+                return;
+
             var type = this.highlight.type;
             this.$el.addClass("focused-" + type);
             this.$el.removeClass(type).removeClass("hover-" + type);
         },
 
         setVisibility: function(value) {
+            if (!this.$el)
+                return;
+
             if (value) {
                 this.$el.css('display', '');
             } else {


### PR DESCRIPTION
Several fixes to improve the performance of highlights rendering:
- Lazy-loading and caching (for the Length lib, and scale calculation)
- Separating calculation from layout to avoid unnecessary web view rendering
- Scheduling renderings to group them
- Some crash guards
