### PR TITLE
bugfix: removing unexpected parameter from generateCfiFromDomRange call

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -879,7 +879,6 @@ var CfiNavigationLogic = function(options) {
         return EPUBcfi.generateRangeComponent(
             range.startContainer, range.startOffset,
             range.endContainer, range.endOffset,
-            range.commonAncestorContainer,
             ['cfi-marker'], [], ["MathJax_Message", "MathJax_SVG_Hidden"]);
     }
 


### PR DESCRIPTION
In generateCfiFromDomRange() function value range.commonAncestorContainer is passed as 5th parameter to EPUBcfi.generateRangeComponent, but in https://github.com/readium/readium-cfi-js/blob/develop/js/cfi_API.js generateRangeComponent 5th parameter is expected to be classBlacklist.

Non-obvious thing is that it leads to false positives inside cfiInstructions.applyBlacklist and invalid cfi calculation for some trivial htmls.