### PR TITLE
Fix for fallback font loader when no stylesheet is found.

### DIFF
--- a/js/views/font_loader.js
+++ b/js/views/font_loader.js
@@ -43,6 +43,11 @@ var FontLoaderFallback = function(document, options) {
         var fontFamilies = [];
         var fontFamilyRules = [];
 
+        // if no style sheets are found return immediately
+        if (!styleSheets || styleSheets.length <= 0) {
+            callback([]);
+        }
+
         var getFontFamilyFromRule = function(rule) {
             if (rule.style && (rule.style.getPropertyValue || rule.style.fontFamily)) {
                 return rule.style.getPropertyValue("font-family") || rule.style.fontFamily;

--- a/js/views/font_loader.js
+++ b/js/views/font_loader.js
@@ -46,6 +46,7 @@ var FontLoaderFallback = function(document, options) {
         // if no style sheets are found return immediately
         if (!styleSheets || styleSheets.length <= 0) {
             callback([]);
+            return;
         }
 
         var getFontFamilyFromRule = function(rule) {


### PR DESCRIPTION
* When using the fallback font loader if no stylesheet is found, spine item
  loading hangs indefinitely. Hybrid iOS and OSX Safari are impacted. Chrome
  uses the native loader so will not trigger the bug.