### PR TITLE
Update iframe_loader.js

### DIFF
--- a/js/views/iframe_loader.js
+++ b/js/views/iframe_loader.js
@@ -49,8 +49,8 @@ var IFrameLoader = function() {
     this.updateIframeEvents = function (iframe) {
 
         _.each(eventListeners, function (value, key) {
+            $(iframe.contentWindow).off(key);
             for (var i = 0, count = value.length; i < count; i++) {
-                $(iframe.contentWindow).off(key);
                 $(iframe.contentWindow).on(key, value[i].callback, value[i].context);
             }
         });


### PR DESCRIPTION
When calling addIFrameEventListener method multiple times for same eventName (and different callbacks), only the last callback is called.
I suggest to put the event disabling instruction (off) out of values for cycle.