### PR TITLE
In CfiNavigationLogic.getVisibleElements, ignore empty <a> tags.

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1278,16 +1278,19 @@ var CfiNavigationLogic = function(options) {
         _.each($elements, function ($node) {
             var isTextNode = ($node[0].nodeType === Node.TEXT_NODE);
             var $element = isTextNode ? $node.parent() : $node;
-            var visibilityPercentage = checkVisibilityByRectangles(
-                $node, true, visibleContentOffsets, frameDimensions);
+	    if (($element[0].tagName !== "A") || $node[0].nodeValue) {
+                // Skip <a> tags with empty content.
+		var visibilityPercentage = checkVisibilityByRectangles(
+                    $node, true, visibleContentOffsets, frameDimensions);
 
-            if (visibilityPercentage) {
-                visibleElements.push({
-                    element: $element[0], // DOM Element is pushed
-                    textNode: isTextNode ? $node[0] : null,
-                    percentVisible: visibilityPercentage
-                });
-            }
+		if (visibilityPercentage) {
+                    visibleElements.push({
+			element: $element[0], // DOM Element is pushed
+			textNode: isTextNode ? $node[0] : null,
+			percentVisible: visibilityPercentage
+                    });
+		}
+	    }
         });
 
         return visibleElements;


### PR DESCRIPTION
See E-mail to Daniel Weck from 25 Apr 2016

A bugfix in the code which manages bookmarks in Readium.
What happened was that after a bookmark was created in page N in a
chapter, when we tried to jump to the bookmark, the reader jumped to
page M such that 0 <= M < N.

The bug was traced to getVisibleElements, which is a function declared in
CfiNavigationLogic. Turns out that empty <a> tags were considered to be visible in pages following the page in whose markup they appear.

It may be a good idea investigate if and which other empty tags should be
considered to be invisible as well.