### PR TITLE
Custom font-family, fixes #73 (WIP)

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -238,11 +238,58 @@ Helpers.Rect.fromElement = function ($element) {
 
     return new Helpers.Rect(offsetLeft, offsetTop, offsetWidth, offsetHeight);
 };
+/**
+ *
+ * @param $epubHtml: The html that is to have font attributes added.
+ * @param fontSize: The font size that is to be added to the element at all locations.
+ * @param fontObj: The font Object containing at minimum the URL, and fontFamilyName (In fields url and fontFamily) respectively. Pass in null's on the object's fields to signal no font.
+ */
 
-Helpers.UpdateHtmlFontSize = function ($epubHtml, fontSize) {
+Helpers.UpdateHtmlFontAttributes = function ($epubHtml, fontSize, fontObj) {
 
     var perf = false;
+    console.log("derek", fontObj);
+    if(fontObj.fontFamily && fontObj.url){
+        
+        var docHead = $("head", $epubHtml);
+        //Add link attribute if the font name is different.
+        var fontFamily = fontObj.fontFamily;
+        var link = $("#helpers-font-url", docHead);
+        if(!link.length){
+            setTimeout(function(){
+                docHead.append($("<link/>", {
+                    "id" : "helpers-font-url",
+                    "data-fontFamily" : fontFamily,
+                    "rel" : "stylesheet",
+                    "type" : "text/css",
+                    "href" : fontObj.url
+                }));
+            }, 0);  
+        }
+        else if(link.attr("data-fontFamily") != fontFamily){
+            link.attr({
+                "data-fontFamily" : fontFamily,
+                "src" : fontObj.url
+            });
+        }
+        
+        //Otherwise, leave the head alone, it's the same font url.
+        var body = $("body", $epubHtml);
+        console.log("derek", "body is", body[0]);
+        body.css({
+            fontFamily: fontFamily
+        });
+        console.log("derek", body.css("fontFamily"));
+    }
+    else{
+        var docHead = $("head", $epubHtml);
+        //Remove the whole link, it's default.
+        var link = $("#helpers-font-url", docHead);
+        if(link.length) link[0].remove();
+    }
+        
 
+    
     // TODO: very slow on Firefox!
     // See https://github.com/readium/readium-shared-js/issues/274
     if (perf) var time1 = window.performance.now();

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -246,9 +246,10 @@ Helpers.Rect.fromElement = function ($element) {
  */
 
 Helpers.UpdateHtmlFontAttributes = function ($epubHtml, fontSize, fontObj) {
+    const NOTHING =0, ADD = 1, REMOVE = 2; //Types for css font family.
 
     var perf = false;
-    console.log("derek", fontObj);
+    var changeFontFamily = NOTHING;
     if(fontObj.fontFamily && fontObj.url){
         
         var docHead = $("head", $epubHtml);
@@ -265,30 +266,24 @@ Helpers.UpdateHtmlFontAttributes = function ($epubHtml, fontSize, fontObj) {
                     "href" : fontObj.url
                 }));
             }, 0);  
+            changeFontFamily = ADD;
         }
         else if(link.attr("data-fontFamily") != fontFamily){
             link.attr({
                 "data-fontFamily" : fontFamily,
                 "src" : fontObj.url
             });
+            changeFontFamily = ADD;
         }
-        
         //Otherwise, leave the head alone, it's the same font url.
-        var body = $("body", $epubHtml);
-        console.log("derek", "body is", body[0]);
-        body.css({
-            fontFamily: fontFamily
-        });
-        console.log("derek", body.css("fontFamily"));
     }
     else{
+        changeFontFamily = REMOVE;
         var docHead = $("head", $epubHtml);
         //Remove the whole link, it's default.
         var link = $("#helpers-font-url", docHead);
         if(link.length) link[0].remove();
     }
-        
-
     
     // TODO: very slow on Firefox!
     // See https://github.com/readium/readium-shared-js/issues/274
@@ -298,25 +293,33 @@ Helpers.UpdateHtmlFontAttributes = function ($epubHtml, fontSize, fontObj) {
     var win = $epubHtml[0].ownerDocument.defaultView;
     var $textblocks = $('p, div, span, h1, h2, h3, h4, h5, h6, li, blockquote, td, pre', $epubHtml);
     var originalLineHeight;
-
+    
 
     // need to do two passes because it is possible to have nested text blocks.
     // If you change the font size of the parent this will then create an inaccurate
     // font size for any children.
     for (var i = 0; i < $textblocks.length; i++) {
         var ele = $textblocks[i],
-            fontSizeAttr = ele.getAttribute('data-original-font-size');
+            fontSizeAttr = ele.getAttribute('data-original-font-size'),
+            fontFamilyAttr = ele.getAttribute('data-original-font-family');
+
 
         if (!fontSizeAttr) {
             var style = win.getComputedStyle(ele);
             var originalFontSize = parseInt(style.fontSize);
-            originalLineHeight = parseInt(style.lineHeight);
-
+            var originalLineHeight = parseInt(style.lineHeight);
             ele.setAttribute('data-original-font-size', originalFontSize);
+
             // getComputedStyle will not calculate the line-height if the value is 'normal'. In this case parseInt will return NaN
             if (originalLineHeight) {
                 ele.setAttribute('data-original-line-height', originalLineHeight);
             }
+        }
+        
+        if (!fontFamilyAttr) {
+            var style = win.getComputedStyle(ele);
+            var originalFontFamily = style.fontFamily;
+            ele.setAttribute('data-original-font-family', originalFontFamily);
         }
     }
 
@@ -325,6 +328,7 @@ Helpers.UpdateHtmlFontAttributes = function ($epubHtml, fontSize, fontObj) {
     for (var i = 0; i < $textblocks.length; i++) {
         var ele = $textblocks[i],
             fontSizeAttr = ele.getAttribute('data-original-font-size'),
+            fontFamilyAttr = ele.getAttribute('data-original-font-family'),
             lineHeightAttr = ele.getAttribute('data-original-line-height'),
             originalFontSize = Number(fontSizeAttr);
 
@@ -335,13 +339,30 @@ Helpers.UpdateHtmlFontAttributes = function ($epubHtml, fontSize, fontObj) {
             originalLineHeight = 0;
         }
 
-        $(ele).css("font-size", (originalFontSize * factor) + 'px');
+        switch(changeFontFamily){
+            case NOTHING:
+                break;
+            case ADD:
+                $(ele).css({
+                    "font-size" : (originalFontSize * factor) + 'px',
+                    "font-family" : fontFamily
+                });
+                break;
+            case REMOVE:
+                $(ele).css({
+                    "font-size" : (originalFontSize * factor) + 'px',
+                    "font-family" : fontFamilyAttr
+                });
+        }
         if (originalLineHeight) {
             $(ele).css("line-height", (originalLineHeight * factor) + 'px');
         }
 
     }
-    $epubHtml.css("font-size", fontSize + "%");
+    $epubHtml.css({
+        "font-size" : fontSize + "%",
+        "font-family" : (changeFontFamily == NOTHING ? "" : fontFamily)
+    });
     
     if (perf) {
         var time2 = window.performance.now();

--- a/js/models/viewer_settings.js
+++ b/js/models/viewer_settings.js
@@ -99,6 +99,7 @@ var ViewerSettings = function(settingsData) {
         mapProperty("columnMaxWidth", settingsData);
         mapProperty("columnMinWidth", settingsData);
         mapProperty("fontSize", settingsData);
+        mapProperty("fontSelection", settingsData);
         mapProperty("mediaOverlaysPreservePlaybackWhenScroll", settingsData);
         mapProperty("mediaOverlaysSkipSkippables", settingsData);
         mapProperty("mediaOverlaysEscapeEscapables", settingsData);

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -404,7 +404,7 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
         if (!_enableBookStyleOverrides) return;
 
         if (_$epubHtml && _viewSettings) {
-            var font = (_viewSettings.fontSelection > 0 ? options.fonts[_viewSettings.fontSelection] : {});
+            var font = (_viewSettings.fontSelection > 0 ? reader.fonts[_viewSettings.fontSelection] : {});
             Helpers.UpdateHtmlFontAttributes(_$epubHtml, _viewSettings.fontSize, font);
         }
     }

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -399,12 +399,13 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
         _pageTransitionHandler.updateOptions(settings);
     };
 
-    function updateHtmlFontSize() {
+    function updateHtmlFontInfo() {
 
         if (!_enableBookStyleOverrides) return;
 
         if (_$epubHtml && _viewSettings) {
-            Helpers.UpdateHtmlFontSize(_$epubHtml, _viewSettings.fontSize);
+            var font = (_viewSettings.fontSelection > 0 ? options.fonts[_viewSettings.fontSelection] : {});
+            Helpers.UpdateHtmlFontAttributes(_$epubHtml, _viewSettings.fontSize, font);
         }
     }
 
@@ -414,7 +415,7 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
 
         if (_$epubHtml) {
             Helpers.setStyles(_bookStyles.getStyles(), _$epubHtml);
-            updateHtmlFontSize();
+            updateHtmlFontInfo();
         }
     };
 

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -542,6 +542,7 @@ console.trace(JSON.stringify(status));
      *
      * @typedef {object} Globals.Views.ReaderView.SettingsData
      * @property {number} fontSize - Font size as percentage
+     * @property {number} fontSelection - Font selection as the number in the list of possible fonts, where 0 is special meaning default.
      * @property {(string|boolean)} syntheticSpread - "auto"|true|false
      * @property {(string|boolean)} scroll - "auto"|true|false
      * @property {boolean} doNotUpdateView - Indicates whether the view should be updated after the settings are applied

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -47,7 +47,6 @@ define(["../globals", "jquery", "underscore", "eventEmitter", "./fixed_view", ".
  * @constructor
  */
 var ReaderView = function (options) {
-
     $.extend(this, new EventEmitter());
 
     var self = this;
@@ -72,6 +71,9 @@ var ReaderView = function (options) {
         handleViewportResizeEnd, 250, 1000, self);
 
     $(window).on("resize.ReadiumSDK.readerView", lazyResize);
+
+    this.fonts = options.fonts;
+
 
     if (options.el instanceof $) {
         _$el = options.el;

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -38,7 +38,6 @@ define(["../globals", "jquery", "underscore", "eventEmitter", "../models/bookmar
  * @constructor
  */
 var ReflowableView = function(options, reader){
-
     $.extend(this, new EventEmitter());
 
     var self = this;
@@ -53,6 +52,7 @@ var ReflowableView = function(options, reader){
     var _isWaitingFrameRender = false;
     var _deferredPageRequest;
     var _fontSize = 100;
+    var _fontSelection = 0;
     var _$contentFrame;
     var _navigationLogic;
     var _$el;
@@ -148,8 +148,9 @@ var ReflowableView = function(options, reader){
         _paginationInfo.columnMinWidth = settings.columnMinWidth;
         
         _fontSize = settings.fontSize;
+        _fontSelection = settings.fontSelection;
 
-        updateHtmlFontSize();
+        updateHtmlFontInfo();
         updateColumnGap();
 
         updateViewportSize();
@@ -220,10 +221,11 @@ var ReflowableView = function(options, reader){
         }
     }
 
-    function updateHtmlFontSize() {
+    function updateHtmlFontInfo() {
 
         if(_$epubHtml) {
-            Helpers.UpdateHtmlFontSize(_$epubHtml, _fontSize);
+            var _curFont = (_fontSelection == 0 ? {} : reader.fonts[_fontSelection-1]);
+            Helpers.UpdateHtmlFontAttributes(_$epubHtml, _fontSize,_curFont);
         }
     }
 
@@ -361,7 +363,7 @@ var ReflowableView = function(options, reader){
         self.applyBookStyles();
         resizeImages();
 
-        updateHtmlFontSize();
+        updateHtmlFontInfo();
         updateColumnGap();
 
 


### PR DESCRIPTION
#### This pull request is a Work In Progress

#### Related issue(s) and/or pull request(s)
None I don't think

### Additional information

I'll add an options item to the ReaderView options.

### Fonts list.

* A fonts list contains font objects.
* font objects are to be defined with three fields.
    * url: A url to load the font from (it should be a css file defining at least one font face). 
    * displayName: Not relevant at all to the shared-js package, it's used by the UI to tell the user the name of the font. Shared-js should just ignore this if it's passed in.
    * fontFamily: The font family of this font. This is the name that css needs in font-family:font-face-name; declarations. 

### Font Settings.

a field has been added to the viewers settings:

* fontSelection: This integer should be a 0 based index. 0 is the default font (I.E. no font is loaded).
* For all other fonts, the index is found by subtracting one from the fontSelection value, and grabbed from the fonts list of options at that index.

### Next work:

* make options take a fonts list.
* update Helpers.UpdateHtmlFontSize = function ($epubHtml, fontSize) { to take a font object.
* it needs a default object for cases where the url should be removed from $epubHtml
* this should manage adding to the head the correct css declaration.
* This should attach the fontFamily to the body (or remove it in the case of default).
* Update views to take advantage of this functionality.