### PR TITLE
Fixes #549 in viewer ToC links within spine item broken

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1145,6 +1145,15 @@ var CfiNavigationLogic = function(options) {
         return pageIndex;
     };
 
+    this.getVerticalOffsetForElement = function ($element) {
+      return this.getVerticalOffsetForPointOnElement($element, 0, 0);
+    };
+
+    this.getVerticalOffsetForPointOnElement = function ($element, x, y) {
+      var elementRect = Helpers.Rect.fromElement($element);
+      return Math.ceil(elementRect.top + y * elementRect.height / 100);
+    };
+
     this.getElementById = function (id) {
 
         var contentDoc = this.getRootDocument();


### PR DESCRIPTION

#### This pull request is a Other - needs review

#### Related issue(s) and/or pull request(s)
https://github.com/readium/readium-js-viewer/issues/549
#253 

### Additional information
This is out of my area of expertise.  I just found that the problem was caused by a missing function. I found the commit where the function was removed and added it back.  Clicking on ToC link now works properly in all variants of scroll Mode selection (selected via Layout pane in settings dialog).

Added back 2 functions that were removed when fixing #253:
getVerticalOffsetForElement() and
getVerticalOffsetForPointOnElement()