### PR TITLE
BUGFIX: getElementByCfi called with wrong params

### DIFF
--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -1212,7 +1212,7 @@ var ScrollView = function (options, isContinuousScroll, reader) {
         forEachItemView(function (pageView) {
             if (pageView.currentSpineItem().idref == spineItemIdref) {
 
-                found = pageView.getNavigator().getElementByCfi(spineItemIdref, cfi, classBlacklist, elementBlacklist, idBlacklist);
+                found = pageView.getNavigator().getElementByCfi(cfi, classBlacklist, elementBlacklist, idBlacklist);
                 return false;
             }
 


### PR DESCRIPTION
#### This pull request is a Finalized

### Additional information
This fixes a bug where ScrollView::getElementByCfi calls
CfiNavigationLogic::getElementByCfi with the wrong parameters.
It's called with spineItemIdref, but should only be called with
cfi (plus blacklists).

from https://github.com/readium/readium-shared-js/blob/develop/js/views/scroll_view.js#L1215:

````javascript
forEachItemView(function (pageView) {
            if (pageView.currentSpineItem().idref == spineItemIdref) {

                found = pageView.getNavigator().getElementByCfi(spineItemIdref, cfi, classBlacklist, elementBlacklist, idBlacklist);
                // should be:
                found = pageView.getNavigator().getElementByCfi(cfi, classBlacklist, elementBlacklist, idBlacklist);

                return false;
}
````