### PR TITLE
BUGFIX: Bubble CONTENT_DOCUMENT_UNLOADED event

### DIFF
--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -684,6 +684,11 @@ var ScrollView = function (options, isContinuousScroll, reader) {
             self.emit(Globals.Events.CONTENT_DOCUMENT_LOAD_START, $iframe, spineItem);
         });
 
+        pageView.on(Globals.Events.CONTENT_DOCUMENT_UNLOADED, function($iframe, spineItem) {
+            Globals.logEvent("CONTENT_DOCUMENT_UNLOADED", "ON", "scroll_view.js [ " + spineItem.href + " ]");
+            self.emit(Globals.Events.CONTENT_DOCUMENT_UNLOADED, $iframe, spineItem);
+        });
+
         pageView.render();
         if (_viewSettings) pageView.setViewSettings(_viewSettings);
 


### PR DESCRIPTION
#### This pull request is a Work In Finalized

### Additional information

This fixes a bug where ScrollView didn't bubble the event emmited from
OnePageView.

In the function createPageViewForSpineItem in scroll_view.js the event CONTENT_DOCUMENT_UNLOADED is not bubbled up from OnePageView to ReaderView.