### PR TITLE
Obsolete code in reader_view.js ( isElementCfiVisible has changed name to isVisibleSpineItemElem...)

### DIFF
--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -1220,13 +1220,6 @@ var ReaderView = function (options) {
         _iframeLoader.addIFrameEventListener(eventName, callback, context);
     };
 
-    this.isElementCfiVisible = function (spineIdRef, contentCfi) {
-        if (!_currentView) {
-            return false;
-        }
-        return _currentView.isElementCfiVisible(spineIdRef, contentCfi);
-    };
-
     var BackgroundAudioTrackManager = function (readerView) {
         var _spineItemIframeMap = {};
         var _wasPlaying = false;


### PR DESCRIPTION
 isElementCfiVisible has changed name to isVisibleSpineItemElementCfi in the views, but the method isElementCfiVisible was still defined in reader_view.js. Just doing some housekeeping.