### PR TITLE
Rdh stop propagation on handled trigger

### DIFF
--- a/js/models/trigger.js
+++ b/js/models/trigger.js
@@ -53,7 +53,7 @@ Trigger.prototype.subscribe = function(dom) {
     var selector = "#" + this.observer;
     var that = this;
     $(selector, dom).on(this.event, function() {
-        that.execute(dom);
+        return that.execute(dom);
     });
 };
 
@@ -85,7 +85,10 @@ Trigger.prototype.execute = function(dom) {
             break;
         default:
             console.log("do not no how to handle trigger " + this.action);
+            return null;
     }
+    return false;   // do not propagate click event; it was already handled
+
 };
     return Trigger;
 });


### PR DESCRIPTION
#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
No related issue.

#### Test cases, sample files


### Additional information
Bibliotheca's hybrid app has a click handler attached to the body tag of the iframe.  If the user clicks the left or right portion of the page, we move to the previous/next page; if they click in the center, we open a menu.

If there is a clickable element on the page that is configured using a <epub:trigger tag, when that element is clicked, the handler is executed.  But the readium code allows the event to bubble, so that our event handler also sees the click and responds.

There is no need for our event handler to fire, since the event was already handled by the code in the epub.
