### PR TITLE
Rdh compute rectangles for svg

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -424,6 +424,17 @@ var CfiNavigationLogic = function(options) {
             clientRectList = range.getClientRects();
         } else {
             clientRectList = $el[0].getClientRects();
+
+            // If the element is something like this: <svg:svg ....><svg:image ....></svg:image></svg:svg> then the svg:image does not produce client rectangles; so we move to the
+            // enclosing svg tag and get those rectangles
+            try {
+                if (clientRectList.length === 0 && $el[0].ownerSVGElement) {
+                    clientRectList = $($el[0].ownerSVGElement)[0].getClientRects();
+                }
+            }
+            catch (e) {
+                // silently swallow up the error; apparently we can't get clientRectList s
+            }
         }
 
         // all the separate rectangles (for detecting position of the element


### PR DESCRIPTION
#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
See #340 

#### Test cases, sample files


### Additional information
In some cases, the book may have an image which is surrounded by a svg tag like this: <svg:svg ....><svg:image ....></svg:image></svg:svg>  In this case, the containing svg must be used to find the client rectangles.  Some epub books have a cover page which is structured like this; with no other content. Without this change, it appears to readium that there is no visible content on the page, because it can't find the first visible cfi.
