### PR TITLE
pageOpenRequest can be a function

### DIFF
--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -408,6 +408,10 @@ var ReaderView = function (options) {
 
         var pageRequestData = undefined;
 
+        if (openBookData.openPageRequest && typeof(openBookData.openPageRequest) === 'function') {
+            openBookData.openPageRequest = openBookData.openPageRequest();
+        }
+
         if (openBookData.openPageRequest) {
 
             if (openBookData.openPageRequest.idref || (openBookData.openPageRequest.contentRefUrl && openBookData.openPageRequest.sourceFileHref)) {


### PR DESCRIPTION
#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
*Example: See also #341

#### Test cases, sample files

### Additional information

If the resource fetcher is a plugin, then allow the plugin to provide the page open request as a function; so that the value of the page open request can be deferred until its needed. 

The Bibliotheca hybrid app makes use of this feature.  The app to initialize readium, then requests the current reading position from a server.  The function waits for that data to be available, and converts it into a CFI that is used when opening the book.
