### PR TITLE
A sample implementation of a resource fetcher plugin.  This plugin of…

### DIFF
--- a/plugins/ResourceFetcherPlugin/main.js
+++ b/plugins/ResourceFetcherPlugin/main.js
@@ -1,0 +1,103 @@
+
+// This is a sample implementation of a resource fetcher plugin.  It is intended to show how a resource fetcher plugin might be written.
+// This plugin uses an ajax call to call to a service to get the contents of a resource.
+//
+// It's based on a plugin used at Bibliotheca to get the contents of an epub from a server.  I've edited this file to remove
+// some functionality specific to Bibliotheca.  The result may or may not be suitiable for your needs.
+
+define(['readium_js_plugins', 'readium_shared_js/globals', '../../../js/epub-fetch/discover_content_type' ],
+    function (Plugins, Globals,ContentTypeDiscovery) {
+    var config = {};
+     Plugins.register("ResourceFetcherPlugin", function (api) {
+
+         api.plugin.CustomResourceFetcher = function(parentFetcher){
+             var ebookURL = parentFetcher.getEbookURL();
+             var ebookURL_filepath = parentFetcher.getEbookURL_FilePath();
+
+             var self = this;
+
+             // INTERNAL FUNCTIONS
+             // PUBLIC API
+             this.shouldConstructDomProgrammatically = function() { return true; }
+             this.resolveURI = function (pathRelativeToPackageRoot) {
+                 var pathRelativeToPackageRootUri = undefined;
+                 try {
+                     pathRelativeToPackageRootUri = new URI(pathRelativeToPackageRoot);
+                 } catch(err) {
+                     console.error(err);
+                     console.log(pathRelativeToPackageRoot);
+                 }
+                 if (pathRelativeToPackageRootUri && pathRelativeToPackageRootUri.is("absolute")) return pathRelativeToPackageRoot; //pathRelativeToPackageRootUri.scheme() == "http://", "https://", "data:", etc.
+
+
+                 var url = ebookURL_filepath;
+                 try {
+                     //url = new URI(relativeUrl).absoluteTo(url).search('').hash('').toString();
+                     url = new URI(url).search('').hash('').toString();
+                 } catch(err) {
+                     console.error(err);
+                     console.log(url);
+                 }
+
+                 return url + (url.charAt(url.length-1) == '/' ? "" : "/") + pathRelativeToPackageRoot;
+             };
+
+             this.fetchFileContents = function(pathRelativeToPackageRoot, isText, fetchCallback, onerror) {
+                 var body={};
+                 var config={ };
+
+                 var success = function(data, textStatus, jqXHR) {
+                     ReadiumSDK.emit('ResourceFetcher-Success', data, pathRelativeToPackageRoot, body, config);
+                     fetchCallback(data);
+                 };
+
+                 var error = function (xhr, status, errorThrown, self) {
+                     onerror(new Error(errorThrown));
+                 }
+
+                 // Hook; someone can listen for this event and modify the config object before the ajax call.
+                 ReadiumSDK.emit('ResourceFetcher-BeforeFetchFileContents', pathRelativeToPackageRoot, isText, config, success,error);
+                 config.isText=isText;
+
+                 var ajaxArguments ={
+                     retryCount: 0,
+                     isText: isText,
+                     headers: {
+                         'Accept': 'application/json',
+                         'Content-Type': 'application/json'
+                     },
+                     url: config.url,
+                     type: 'POST',
+                     dataType: 'json',
+                     data: JSON.stringify(body),
+                     success: success,
+                     error: error
+                 }
+
+                 $.ajax(ajaxArguments);
+             };
+
+             this.fetchFileContentsText = function(pathRelativeToPackageRoot, fetchCallback, onerror) {
+                 this.fetchFileContents(pathRelativeToPackageRoot, true, function (result) {
+                     fetchCallback(result);
+                 }, onerror);
+             };
+
+             this.fetchFileContentsBlob = function(pathRelativeToPackageRoot, fetchCallback, onerror) {
+                 this.fetchFileContents(pathRelativeToPackageRoot, false, function(result) {
+                     var contentType = ContentTypeDiscovery.identifyContentTypeFromFileName(pathRelativeToPackageRoot);
+                     var bytes = new Uint8Array(result.length); for (var i=0; i<result.length; i++) bytes[i] = result.charCodeAt(i);
+                     var blob = new Blob([bytes],{type: contentType});
+                     fetchCallback(blob);
+                 },onerror);
+             };
+
+         };
+         api.plugin.CustomResourceFetcher.openPackageDocument = function(ebookURL, callback, openPageRequest, openPackageDocument_) {
+             openPackageDocument_(ebookURL, callback, openPageRequest, '');
+         }
+     });
+
+    return config;
+});
+


### PR DESCRIPTION
#### This pull request is a Sample Implementation

#### Related issue(s) and/or pull request(s)

There will shortly be a pull request that allows readium to support Resource Fetcher Plugins; that code needs to be merged in for this sample to be useful.

#### Test cases, sample files
### Additional information
The Bibliotheca hybrid app gets the contents of epubs by making api calls to a server; the payload of the request is a list of one or more files that readium needs to get from the epub.  The server opens the epub, extracts the required files, and sends them over the wire back to the client.  When the client receives the files, the appropriate callbacks are executed with the contents of the file.

Bibliotheca uses a plugin to provide this functionality.  (The plugin code is considered intellectual property, so is not included here).  The plugin offers the capability of over-the-wire content encryption, file request batching, and request retry on failure.

This sample implementation of a resource fetcher plugin shows a simple call to an API.  This plugin offers a reference implementation only; modification and testing in your environment is encouraged.  This resource fetcher calls out to an API endpoint to get the desired resource.  

The event 'ResourceFetcher-BeforeFetchFileContents' is emitted; it is expected that some code is listening to that event, and constructs an appropriate URL and body to be sent to the API, based on the filename, perhaps; in that method the config.url property should get the constructed url.
 
I would expect that the maintainers of the repo would edit this file further before making it public; fixing formatting, comments, and maybe revising the functionality a little bit.