### PR TITLE
fixed CSSOM naming discrepancy (cssom NPM module)

### DIFF
--- a/package.cson
+++ b/package.cson
@@ -127,7 +127,7 @@ devDependencies:
     
     "es6-collections": 'latest'
 
-    "CSSOM": 'danielweck/CSSOM#gh-pages'
+    "cssom": 'danielweck/CSSOM#gh-pages'
     #"CSSOM": 'NV/CSSOM#gh-pages'
 
     "ResizeSensor": 'danielweck/css-element-queries'

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "urijs": "danielweck/URI.js",
     "eventemitter3": "latest",
     "es6-collections": "latest",
-    "CSSOM": "danielweck/CSSOM#gh-pages",
+    "cssom": "danielweck/CSSOM#gh-pages",
     "ResizeSensor": "danielweck/css-element-queries"
   },
   "scripts": {


### PR DESCRIPTION
Fix module name in `package.json`: "CSSOM" -> "cssom" 

#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)

#362

#### Test cases, sample files

### Additional information

