### PR TITLE
Change "ResizeSensor" -> "css-element-queries" to match name field in…

### DIFF
--- a/package.cson
+++ b/package.cson
@@ -130,7 +130,7 @@ devDependencies:
     "cssom": 'danielweck/CSSOM'
     #"CSSOM": 'NV/CSSOM'
 
-    "ResizeSensor": 'danielweck/css-element-queries'
+    "css-element-queries": 'danielweck/css-element-queries'
     
 
 # Below dependencies are only used for building tasks (above are runtime deps):

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eventemitter3": "latest",
     "es6-collections": "latest",
     "cssom": "danielweck/CSSOM",
-    "ResizeSensor": "danielweck/css-element-queries"
+    "css-element-queries": "danielweck/css-element-queries"
   },
   "scripts": {
     "cson2json": "node ./readium-cfi-js/node_modules/cson/bin/cson2json package.cson > package.json && node readium-cfi-js/readium-build-tools/optimizePackageJsonScripts.js",


### PR DESCRIPTION
Fix module name in `package.json`: "ResizeSensor" -> "css-element-queries" 

#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)

#373 

#### Test cases, sample files

### Additional information

