### PR TITLE
Fix #375

### DIFF
--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -932,7 +932,7 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
             $iframe: _$iframe,
             frameDimensions: getFrameDimensions,
             visibleContentOffsets: getVisibleContentOffsets,
-            classBlacklist: ["cfi-marker", "mo-cfi-highlight", "resize-sensor", "resize-sensor-expand", "resize-sensor-shrink"],
+            classBlacklist: ["cfi-marker", "mo-cfi-highlight", "resize-sensor", "resize-sensor-expand", "resize-sensor-shrink", "resize-sensor-inner"],
             elementBlacklist: [],
             idBlacklist: ["MathJax_Message", "MathJax_SVG_Hidden"]
         });


### PR DESCRIPTION
Add ‘resize-sensor-inner’ to one page view’s cfi blacklist.
It was included in the reflow view, but missing in the one page view

This fixes the call to `getLastVisibleCfi` when using the scroll setting