### PR TITLE
Readium shared issue #386, added helper function for node.parentElement

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1387,7 +1387,7 @@ var CfiNavigationLogic = function(options) {
 
     function isElementBlacklisted(element) {
         var isBlacklisted = false;
-        var classAttribute = element.className;
+        var classAttribute = element.getAttribute("class");
         var classList = classAttribute ? classAttribute.split(' ') : [];
         var id = element.id;
 


### PR DESCRIPTION
Because IE returns null for text nodes


#### Related issue
https://github.com/readium/readium-shared-js/issues/386

### Additional information
Added function getParentElement which return node.parentElement if it is defined (chrome/firefox/safari/etc)  or searches for the closest element in internet explorer 10 & 11
