### PR TITLE
CFI related improvements

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -452,15 +452,8 @@ var CfiNavigationLogic = function (options) {
                 //noinspection JSUnresolvedFunction
                 clientRectList = range.getClientRects();
             } else {
-                if ($el.parent()[0].tagName === "video"){
-                    // create a rect using the video
-                    var videoRect = $el.parent()[0].getClientRects();
-                    clientRectList = videoRect;
-                } else {
-                    //noinspection JSUnresolvedFunction
-                    clientRectList = $el[0].getClientRects();
-
-                }
+                //noinspection JSUnresolvedFunction
+                clientRectList = $el[0].getClientRects();
             }
 
             // all the separate rectangles (for detecting position of the element
@@ -891,9 +884,6 @@ var CfiNavigationLogic = function (options) {
             // we need to also check for medai elements as a cfi
             } else {
                 //if not then generate a CFI for the element
-                if ( element.parentElement.nodeName === "video") {
-                    element = element.parentElement;
-                }
                 return self.getCfiForElement(element);
             }
         }

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -761,8 +761,8 @@ var CfiNavigationLogic = function (options) {
 
             //Split Ratio depends whether we are searching for the lastCFI or first CFI, last CFI will most likely be near the end of the given view , so we allocate the spliting to be 60/40
             // 40/60 for firstCFI
-
-            var outputRange = getTextRangeOffset(splitRange(nodeRange, parseFloat(50)), visibleContentOffsets, pickerFunc([0, 1]),
+            var splitRatio = pickerFunc([0,1]) == 0 ? 40 : 60;
+            var outputRange = getTextRangeOffset(splitRange(nodeRange, parseFloat(splitRatio)), visibleContentOffsets, pickerFunc([0, 1]),
                 function (rect) {
                     return (isVerticalWritingMode() ? rect.height : rect.width) && isRectVisible(rect, false, frameDimensions);
                 });
@@ -783,6 +783,9 @@ var CfiNavigationLogic = function (options) {
 
             var currRange = startingSet;
             var count = 1 ;
+            //split ratio determined by directionBit
+            var splitRatio = directionBit ==0 ? 40 :60;
+
 
             //begin iterative binary search, each iteration will check Range length and visibility
             // if current range has visible fragments we check the range length
@@ -792,11 +795,11 @@ var CfiNavigationLogic = function (options) {
                 if(currRange.length <= 1) { return currRange;}
                 var currTextNodeFragments = getRangeClientRectList(currRange[directionBit], visibleContentOffsets);
                 if (fragmentVisible(currTextNodeFragments, filterfunc)) {
-                    currRange = splitRange(currRange[directionBit], parseFloat(50));
+                    currRange = splitRange(currRange[directionBit], parseFloat(splitRatio));
                 }
                     // No visible fragment Look in other half
                  else {
-                    currRange = splitRange(currRange[changeDirection(directionBit)], parseFloat(50));
+                    currRange = splitRange(currRange[changeDirection(directionBit)], parseFloat(splitRatio));
                  }
             }
             console.log(count);

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1079,7 +1079,7 @@ var CfiNavigationLogic = function (options) {
             var chosenNode;
             var isTextNode;
 
-            var siblingTextNodesAndSelf = _.filter(element.parentElement.childNodes, function (n) {
+            var siblingTextNodesAndSelf = _.filter(element.parentNode.childNodes, function (n) {
                 return n === element || isValidTextNode(n);
             });
 
@@ -1108,7 +1108,7 @@ var CfiNavigationLogic = function (options) {
             } else if (isElementNode(element.nextElementSibling)) {
                 chosenNode = element.nextElementSibling;
             } else {
-                chosenNode = element.parentElement;
+                chosenNode = element.parentNode;
             }
 
             if (isTextNode) {
@@ -1374,7 +1374,7 @@ var CfiNavigationLogic = function (options) {
             while ((node = nodeIterator.nextNode())) {
                 var isLeafNode = node.nodeType === Node.ELEMENT_NODE && !node.childElementCount && !isValidTextNodeContent(node.textContent);
                 if (isLeafNode || isValidTextNode(node)){
-                    var element = (node.nodeType === Node.TEXT_NODE) ? node.parentElement : node;
+                    var element = (node.nodeType === Node.TEXT_NODE) ? node.parentNode : node;
                     if (!isElementBlacklisted(element)) {
                         $leafNodeElements.push($(node));
                     }

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -719,7 +719,7 @@ var CfiNavigationLogic = function (options) {
             if (range.endOffset - range.startOffset === 1) {
                 return [range];
             }
-            var length = determineSplit(range, parseFloat(division));
+            var length = determineSplit(range, division);
             var textNode = range.startContainer;
             var leftNodeRange = range.cloneRange();
             leftNodeRange.setStart(textNode, range.startOffset);
@@ -739,7 +739,7 @@ var CfiNavigationLogic = function (options) {
             var nodeRange = createRangeFromNode(textNode);
             var nodeClientRects = getRangeClientRectList(nodeRange, visibleContentOffsets);
             var splitRatio = deterministicSplit(nodeClientRects, pickerFunc([0, 1]));
-            return getTextRangeOffset(splitRange(nodeRange, parseFloat(splitRatio)), visibleContentOffsets,
+            return getTextRangeOffset(splitRange(nodeRange, splitRatio), visibleContentOffsets,
                 pickerFunc([0, 1]), splitRatio,
                 function (rect) {
                     return (isVerticalWritingMode() ? rect.height : rect.width) && isRectVisible(rect, false, frameDimensions);
@@ -761,7 +761,7 @@ var CfiNavigationLogic = function (options) {
                 // heuristic: slight bias to increase likelihood of hits
                 return directionBit ? 55 : 45;
             } else {
-                split = parseFloat(visibleRectHeight / totalHeight) * 100;
+                split = 100 * (visibleRectHeight / totalHeight);
                 return invisibleRectHeight > visibleRectHeight ? split + 5 : split - 5;
             }
         }
@@ -801,11 +801,11 @@ var CfiNavigationLogic = function (options) {
                 runCount++;
                 var currTextNodeFragments = getRangeClientRectList(currRange[directionBit], visibleContentOffsets);
                 if (hasVisibleFragments(currTextNodeFragments, filterFunc)) {
-                    currRange = splitRange(currRange[directionBit], parseFloat(splitRatio));
+                    currRange = splitRange(currRange[directionBit], splitRatio);
                 }
                 // No visible fragment Look in other half
                 else {
-                    currRange = splitRange(currRange[directionBit ? 0 : 1], parseFloat(splitRatio));
+                    currRange = splitRange(currRange[directionBit ? 0 : 1], splitRatio);
                 }
             }
             if (DEBUG) console.debug('getVisibleTextRangeOffsets:getTextRangeOffset:runCount', runCount);

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1500,9 +1500,12 @@ var CfiNavigationLogic = function (options) {
 
             var treeWalker = document.createTreeWalker(
                 this.getBodyElement(),
-                NodeFilter.SHOW_ELEMENT,
+                NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
                 function(node) {
-                    if (isElementBlacklisted($(node)))
+                    if (node.nodeType === Node.ELEMENT_NODE && isElementBlacklisted($(node)))
+                        return NodeFilter.FILTER_REJECT;
+
+                    if (node.nodeType === Node.TEXT_NODE && !isValidTextNode(node))
                         return NodeFilter.FILTER_REJECT;
 
                     var visibilityResult = checkVisibilityByRectangles($(node), true, visibleContentOffsets, frameDimensions);
@@ -1513,9 +1516,18 @@ var CfiNavigationLogic = function (options) {
 
             while (treeWalker.nextNode()) {
                 var node = treeWalker.currentNode;
+
+                if (node.nodeType === Node.TEXT_NODE) {
+                    firstVisibleElement = node.parentNode;
+                    textNode = node;
+                    percentVisible = 100; // not really used, assume this value unless otherwise
+                    break;
+                }
+
                 var hasChildElements = false;
                 var hasChildTextNodes = false;
-                for (var i=0; i<node.childNodes.length; i++) {
+
+                for (var i = node.childNodes.length - 1; i >= 0; i--) {
                     var childNode = node.childNodes[i];
                     if (childNode.nodeType === Node.ELEMENT_NODE) {
                         hasChildElements = true;
@@ -1526,31 +1538,24 @@ var CfiNavigationLogic = function (options) {
                 }
 
                 // potentially stop tree traversal when first element hit with no child element nodes
-                if (!hasChildElements) {
-                    // case 1: image
-                    if (node.nodeName.toLowerCase() === 'img') {
-                        firstVisibleElement = node;
-                        percentVisible = 100; // unused
-                        break;    
-                    }
-                    
-                    // case 2: valid text node
-                    if (hasChildTextNodes) {
-                        for (var i=0; i<node.childNodes.length; ++i) {
-                            var childNode = node.childNodes[i];
-                            if (childNode.nodeType === Node.TEXT_NODE && isValidTextNode(childNode)) {
-                                var visibilityResult = checkVisibilityByRectangles($(childNode), true, visibleContentOffsets, frameDimensions);
-                                if (visibilityResult) {
-                                    firstVisibleElement = node;
-                                    textNode = childNode;
-                                    percentVisible = visibilityResult;
-                                    break;
-                                }
+                if (!hasChildElements && hasChildTextNodes) {
+                    for (var i=node.childNodes.length-1; i>=0; i--) {
+                        var childNode = node.childNodes[i];
+                        if (childNode.nodeType === Node.TEXT_NODE && isValidTextNode(childNode)) {
+                            var visibilityResult = checkVisibilityByRectangles($(childNode), true, visibleContentOffsets, frameDimensions);
+                            if (visibilityResult) {
+                                firstVisibleElement = node;
+                                textNode = childNode;
+                                percentVisible = visibilityResult;
+                                break;
                             }
                         }
-                        if (firstVisibleElement)
-                            break;
                     }
+                } else if (!hasChildElements) {
+                    firstVisibleElement = node;
+                    percentVisible = 100;
+                    textNode = null;
+                    break;
                 }
             }
 
@@ -1574,9 +1579,12 @@ var CfiNavigationLogic = function (options) {
 
             var treeWalker = document.createTreeWalker(
                 this.getBodyElement(),
-                NodeFilter.SHOW_ELEMENT,
+                NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
                 function(node) {
-                    if (isElementBlacklisted($(node)))
+                    if (node.nodeType === Node.ELEMENT_NODE && isElementBlacklisted($(node)))
+                        return NodeFilter.FILTER_REJECT;
+
+                    if (node.nodeType === Node.TEXT_NODE && !isValidTextNode(node))
                         return NodeFilter.FILTER_REJECT;
 
                     var visibilityResult = checkVisibilityByRectangles($(node), true, visibleContentOffsets, frameDimensions);
@@ -1589,9 +1597,18 @@ var CfiNavigationLogic = function (options) {
 
             do {
                 var node = treeWalker.currentNode;
+
+                if (node.nodeType === Node.TEXT_NODE) {
+                    firstVisibleElement = node.parentNode;
+                    textNode = node;
+                    percentVisible = 100; // not really used, assume this value unless otherwise
+                    break;
+                }
+
                 var hasChildElements = false;
                 var hasChildTextNodes = false;
-                for (var i=node.childNodes.length-1; i>=0; i--) {
+
+                for (var i = node.childNodes.length - 1; i >= 0; i--) {
                     var childNode = node.childNodes[i];
                     if (childNode.nodeType === Node.ELEMENT_NODE) {
                         hasChildElements = true;
@@ -1602,31 +1619,24 @@ var CfiNavigationLogic = function (options) {
                 }
 
                 // potentially stop tree traversal when first element hit with no child element nodes
-                if (!hasChildElements) {
-                    // case 1: image
-                    if (node.nodeName.toLowerCase() === 'img') {
-                        firstVisibleElement = node;
-                        percentVisible = 100; // unused
-                        break;    
-                    }
-                    
-                    // case 2: valid text node
-                    if (hasChildTextNodes) {
-                        for (var i=node.childNodes.length-1; i>=0; i--) {
-                            var childNode = node.childNodes[i];
-                            if (childNode.nodeType === Node.TEXT_NODE && isValidTextNode(childNode)) {
-                                var visibilityResult = checkVisibilityByRectangles($(childNode), true, visibleContentOffsets, frameDimensions);
-                                if (visibilityResult) {
-                                    firstVisibleElement = node;
-                                    textNode = childNode;
-                                    percentVisible = visibilityResult;
-                                    break;
-                                }
+                if (!hasChildElements && hasChildTextNodes) {
+                    for (var i=node.childNodes.length-1; i>=0; i--) {
+                        var childNode = node.childNodes[i];
+                        if (childNode.nodeType === Node.TEXT_NODE && isValidTextNode(childNode)) {
+                            var visibilityResult = checkVisibilityByRectangles($(childNode), true, visibleContentOffsets, frameDimensions);
+                            if (visibilityResult) {
+                                firstVisibleElement = node;
+                                textNode = childNode;
+                                percentVisible = visibilityResult;
+                                break;
                             }
                         }
-                        if (firstVisibleElement)
-                            break;
                     }
+                } else if (!hasChildElements) {
+                    firstVisibleElement = node;
+                    percentVisible = 100;
+                    textNode = null;
+                    break;
                 }
             } while (treeWalker.previousNode());
 

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1313,6 +1313,25 @@ var CfiNavigationLogic = function (options) {
             return visibleElements;
         };
 
+        function getBaseCfiSelectedByFunc(pickerFunc) {
+            var $elements = self.getLeafNodeElements($(self.getBodyElement()));
+            var $selectedNode = pickerFunc($elements);
+            var collapseToStart = pickerFunc([true, false]);
+            var range = createRange();
+            range.selectNodeContents($selectedNode[0]);
+            range.collapse(collapseToStart);
+            return generateCfiFromDomRange(range);
+        }
+
+        this.getStartCfi = function () {
+            return getBaseCfiSelectedByFunc(_.first);
+        };
+
+
+        this.getEndCfi = function () {
+            return getBaseCfiSelectedByFunc(_.last);
+        };
+
         this.getElementsWithFilter = function ($root, filterFunction) {
 
             var $elements = [];

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1689,6 +1689,9 @@ var CfiNavigationLogic = function (options) {
                 }
             }
 
+            if (!firstVisibleElement) {
+                return null;
+            }
             return {
                 element: firstVisibleElement,
                 textNode: textNode,
@@ -1770,6 +1773,9 @@ var CfiNavigationLogic = function (options) {
                 }
             } while (treeWalker.previousNode());
 
+            if (!firstVisibleElement) {
+                return null;
+            }
             return {
                 element: firstVisibleElement,
                 textNode: textNode,

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -41,7 +41,10 @@ var CfiNavigationLogic = function (options) {
     var self = this;
     options = options || {};
 
-    var DEBUG = ReadiumSDK.DEBUG_MODE;
+    var _DEBUG = ReadiumSDK.DEBUG_MODE;
+    if (_DEBUG) {
+        window.top._DEBUG_visibleTextRangeOffsetsRuns = window.top._DEBUG_visibleTextRangeOffsetsRuns || [];
+    }
 
     this.getRootElement = function () {
 
@@ -661,7 +664,7 @@ var CfiNavigationLogic = function (options) {
                     commonAncestorContainer: range.commonAncestorContainer
                 };
 
-                if (DEBUG) {
+                if (_DEBUG) {
                     drawDebugOverlayFromDomRange(wrappedRange);
                 }
 
@@ -808,7 +811,10 @@ var CfiNavigationLogic = function (options) {
                     currRange = splitRange(currRange[directionBit ? 0 : 1], splitRatio);
                 }
             }
-            if (DEBUG) console.debug('getVisibleTextRangeOffsets:getTextRangeOffset:runCount', runCount);
+            if (_DEBUG) {
+                console.debug('getVisibleTextRangeOffsets:getTextRangeOffset:runCount', runCount);
+                window.top._DEBUG_visibleTextRangeOffsetsRuns.push(runCount);
+            }
             return currRange[0];
         }
 
@@ -844,7 +850,7 @@ var CfiNavigationLogic = function (options) {
             var textNode = visibleLeafNode.textNode;
 
             if (targetLeafNode && element !== startingParent && !_.contains($(textNode || element).parents(), startingParent)) {
-                if (DEBUG) console.warn("findVisibleLeafNodeCfi: stopped recursion early");
+                if (_DEBUG) console.warn("findVisibleLeafNodeCfi: stopped recursion early");
                 return null;
             }
             //if a valid text node is found, try to generate a CFI with range offsets
@@ -1008,7 +1014,7 @@ var CfiNavigationLogic = function (options) {
                         this.getElementBlacklist(),
                         this.getIdBlacklist());
 
-                    if (DEBUG) {
+                    if (_DEBUG) {
                         console.log(nodeResult);
                     }
                 } catch (ex) {
@@ -1031,7 +1037,7 @@ var CfiNavigationLogic = function (options) {
                             endRangeInfo.offset)
                         : null;
 
-                if (DEBUG) {
+                if (_DEBUG) {
                     console.log(nodeRangeClientRect);
                     addOverlayRect(nodeRangeClientRect, 'purple', contentDoc);
                 }
@@ -1372,7 +1378,7 @@ var CfiNavigationLogic = function (options) {
             _cache._invalidate();
         };
 
-        //if (DEBUG) {
+        //if (_DEBUG) {
 
         var $debugOverlays = [];
 
@@ -1470,6 +1476,12 @@ var CfiNavigationLogic = function (options) {
                 var cfi2 = ReadiumSDK.reader.getLastVisibleCfi();
                 var range2 = ReadiumSDK.reader.getDomRangeFromRangeCfi(cfi2);
                 console.log(cfi2, range2, drawDebugOverlayFromDomRange(range2));
+            },
+            visibleTextRangeOffsetsRunsAvg: function () {
+                var arr = window.top._DEBUG_visibleTextRangeOffsetsRuns;
+                return arr.reduce(function (a, b) {
+                        return a + b;
+                    }) / arr.length;
             }
         };
 

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -761,7 +761,7 @@ var CfiNavigationLogic = function (options) {
             var nodeRange = createRangeFromNode(textNode);
             // split the range into two halves
             var nodeClientRects = getRangeClientRectList(nodeRange,visibleContentOffsets);
-            //console.log(heightOfRect(nodeRange));
+            rectTopHash(nodeClientRects);
              //Split Ratio depends swhether we are searching for the lastCFI or first CFI, last CFI will most likely be near the end of the given view , so we allocate the spliting to be 60/40
             // 40/60 for firstCFI
             var splitRatio = deterministicSplit(nodeClientRects);

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -38,7 +38,6 @@
 define(["jquery", "underscore", "../helpers", 'readium_cfi_js'], function($, _, Helpers, epubCfi) {
 
 var CfiNavigationLogic = function (options) {
-
     var self = this;
     options = options || {};
 
@@ -116,9 +115,9 @@ var CfiNavigationLogic = function (options) {
         visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
 
         //noinspection JSUnresolvedFunction
-       // console.log(range.getClientRects().length);
+
         return _.map(range.getClientRects(), function (rect) {
-           // console.log(rect);
+
             return normalizeRectangle(rect, visibleContentOffsets.left, visibleContentOffsets.top);
         });
     }
@@ -460,7 +459,7 @@ var CfiNavigationLogic = function (options) {
                 } else {
                     //noinspection JSUnresolvedFunction
                     clientRectList = $el[0].getClientRects();
-                    console.log(clientRectList);
+
                 }
             }
 
@@ -696,7 +695,6 @@ var CfiNavigationLogic = function (options) {
                 console.log('Did not generate a valid CFI:' + cfi);
                 return undefined;
             }
-
             return cfi;
         };
 
@@ -735,15 +733,13 @@ var CfiNavigationLogic = function (options) {
 
         var DEBUG = false;
 
-
-
         function determineSplit (Range,division) {
-            //either  50/50 or 60 /40
            var percent = parseFloat(division)/parseFloat(100);
            var length =  Math.round((Range.endOffset - Range.startOffset )* percent);
            return length;
 
         }
+
         function splitRange(Range, division) {
             if ( Range.endOffset-Range.startOffset == 1){return [Range];}
             var length = determineSplit(Range,parseFloat(division));
@@ -763,11 +759,8 @@ var CfiNavigationLogic = function (options) {
         function getVisibleTextRangeOffsets(textNode, pickerFunc, visibleContentOffsets, frameDimensions) {
             visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
 
-            // Create a Range around targeted textNode
             var nodeRange = createRangeFromNode(textNode);
-            // split the range into two halves
             var nodeClientRects = getRangeClientRectList(nodeRange,visibleContentOffsets);
-             //Split Ratio depends swhether we are searching for the lastCFI or first CFI, last CFI will most likely be near the end of the given view , so we allocate the spliting to be 60/40
             // 40/60 for firstCFI
             var splitRatio = deterministicSplit(nodeClientRects,pickerFunc([0,1]));
             var outputRange = getTextRangeOffset(splitRange(nodeRange, parseFloat(splitRatio)), visibleContentOffsets ,pickerFunc([0, 1]), splitRatio,
@@ -775,30 +768,30 @@ var CfiNavigationLogic = function (options) {
                     return (isVerticalWritingMode() ? rect.height : rect.width) && isRectVisible(rect, false, frameDimensions);
                 });
             return outputRange;
-            // Split Range into two halves for binary search implementation
-
         }
 
 
         function deterministicSplit (rectList,directionBit) {
+            var split = 0 ;
             // Calculate total cumulate Height for both visible portions and invisible portions and find the split
             var visibleRects = _.filter(rectList,function (rect) {
                 return (isVerticalWritingMode() ? rect.height : rect.width) && isRectVisible(rect, false, getFrameDimensions());
             });
             var visibleRectHeight = calculateCumulativeHeight(visibleRects);
+            var invisibleRectHeight = totalHeight - visibleRectHeight;
             var totalHeight = calculateCumulativeHeight(rectList);
+
             if (visibleRectHeight == totalHeight ){
                 // either all visible or its a 50/50 split
                 if (directionBit == 0) {
-                    return 40;
-
+                    return 45;
                 }else {
-                    return 60;
+                    return 55;
                 }
             } else {
-                return ((parseFloat(visibleRectHeight/totalHeight) * 100));
+                split =  ((parseFloat(visibleRectHeight/totalHeight) * 100));
+                return invisibleRectHeight > visibleRectHeight ? split+5 : split -5;
             }
-
         }
 
         function rectTopHash (rectList) {
@@ -836,19 +829,9 @@ var CfiNavigationLogic = function (options) {
         function getTextRangeOffset(startingSet, visibleContentOffsets, directionBit,splitRatio, filterfunc) {
 
             var currRange = startingSet;
-            var count = 1 ;
-            //split ratio determined by directionBit
-
-
             //begin iterative binary search, each iteration will check Range length and visibility
-            // if current range has visible fragments we check the range length
-            // if not visible check the other half.
             while (currRange.length !=1) {
-
-                count ++;
-
                 var currTextNodeFragments = getRangeClientRectList(currRange[directionBit], visibleContentOffsets);
-
                 if (fragmentVisible(currTextNodeFragments, filterfunc)) {
                     currRange = splitRange(currRange[directionBit], parseFloat(splitRatio));
                 }
@@ -857,13 +840,11 @@ var CfiNavigationLogic = function (options) {
                     currRange = splitRange(currRange[changeDirection(directionBit)], parseFloat(splitRatio));
                  }
             }
-
             return currRange[0];
         }
 
         function fragmentVisible(fragments,filterfunc) {
             var visibleFragments = _.filter(fragments,filterfunc);
-            var testBool = visibleFragments.length? true: false;
             return visibleFragments.length ? true : false;
         }
 
@@ -1357,7 +1338,6 @@ var CfiNavigationLogic = function (options) {
             if (_cacheEnabled) {
                 _cache.leafNodeElements.set($root, $leafNodeElements);
             }
-
             return $leafNodeElements;
         };
 

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -187,7 +187,7 @@ var CfiNavigationLogic = function (options) {
             return false;
         }
 
-        if (isPaginatedView()) {
+        if (isPaginatedView() && !isVerticalWritingMode()) {
             return (rect.left >= 0 && rect.left < frameDimensions.width) ||
                 (!ignorePartiallyVisible && rect.left < 0 && rect.right > 0);
         } else {

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -189,10 +189,10 @@ var CfiNavigationLogic = function (options) {
 
         if (isPaginatedView()) {
             return (rect.left >= 0 && rect.left < frameDimensions.width) ||
-                (!ignorePartiallyVisible && rect.left < 0 && rect.right >= 0);
+                (!ignorePartiallyVisible && rect.left < 0 && rect.right > 0);
         } else {
             return (rect.top >= 0 && rect.top < frameDimensions.height) ||
-                (!ignorePartiallyVisible && rect.top < 0 && rect.bottom >= 0);
+                (!ignorePartiallyVisible && rect.top < 0 && rect.bottom > 0);
         }
 
     }

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -41,7 +41,7 @@ var CfiNavigationLogic = function (options) {
     var self = this;
     options = options || {};
 
-    var debugMode = ReadiumSDK.DEBUG_MODE;
+    var DEBUG = ReadiumSDK.DEBUG_MODE;
 
     this.getRootElement = function () {
 
@@ -661,7 +661,7 @@ var CfiNavigationLogic = function (options) {
                     commonAncestorContainer: range.commonAncestorContainer
                 };
 
-                if (debugMode) {
+                if (DEBUG) {
                     drawDebugOverlayFromDomRange(wrappedRange);
                 }
 
@@ -709,8 +709,6 @@ var CfiNavigationLogic = function (options) {
             }
             return generateCfiFromDomRange(range);
         };
-
-        var DEBUG = false;
 
         function determineSplit(range, division) {
             var percent = division / 100;
@@ -1010,7 +1008,7 @@ var CfiNavigationLogic = function (options) {
                         this.getElementBlacklist(),
                         this.getIdBlacklist());
 
-                    if (debugMode) {
+                    if (DEBUG) {
                         console.log(nodeResult);
                     }
                 } catch (ex) {
@@ -1033,7 +1031,7 @@ var CfiNavigationLogic = function (options) {
                             endRangeInfo.offset)
                         : null;
 
-                if (debugMode) {
+                if (DEBUG) {
                     console.log(nodeRangeClientRect);
                     addOverlayRect(nodeRangeClientRect, 'purple', contentDoc);
                 }
@@ -1374,7 +1372,7 @@ var CfiNavigationLogic = function (options) {
             _cache._invalidate();
         };
 
-        //if (debugMode) {
+        //if (DEBUG) {
 
         var $debugOverlays = [];
 

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1170,10 +1170,17 @@ var CfiNavigationLogic = function (options) {
 
         this.getPageIndexDeltaForElement = function ($element) {
 
+            // first try to get delta by rectangles
             var pageIndex = findPageIndexDeltaByRectangles($element);
+
+            // for hidden elements (e.g., page breaks) there are no rectangles
             if (pageIndex === null) {
-                //Attempted to locate a hidden element, try a fallback with best guess
-                return findPageIndexDeltaByRectangles(this.getNearestCfiFromElement($element[0]));
+
+                // get CFI of the nearest (to hidden) element, and then get CFI's element
+                var nearestVisibleElement = this.getElementByCfi(this.getNearestCfiFromElement($element[0]));
+
+                // find page index by rectangles again, for the nearest element
+                return findPageIndexDeltaByRectangles(nearestVisibleElement);
             }
             return pageIndex;
         };

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -791,20 +791,17 @@ var CfiNavigationLogic = function (options) {
         function rectTopHash (rectList) {
             // sort the rectangles by top value
             var sortedList = rectList.sort(function (a,b) { return (a.top < b.top );});
-            console.log(sortedList);
             var lineMap =[];
             for ( rect in sortedList ){
                     var key = rect.top;
                     if (lineMap[key] == null) {
                     lineMap[key] = [rect.height];
                 } else {
-                    console.log(lineMap[key]);
                     var currentLine = lineMap[key];
                     currentLine.push(rect.height);
                     lineMap[key] = currentLine;
                 }
             }
-            console.log(lineMap);
         }
 
         function calculateCumulativeHeight (rectList) {

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -293,13 +293,18 @@ var CfiNavigationLogic = function (options) {
                 }
 
                 if (isRectVisible(adjustedRect, false, frameDimensions)) {
-                    //it might still be partially visible in webkit
                     if (shouldCalculateVisibilityPercentage && adjustedRect.top < 0) {
                         visibilityPercentage =
                             Math.floor(100 * (adjustedRect.height + adjustedRect.top) / adjustedRect.height);
                     } else if (shouldCalculateVisibilityPercentage && adjustedRect.bottom > frameDimensions.height) {
                         visibilityPercentage =
                             Math.floor(100 * (frameDimensions.height - adjustedRect.top) / adjustedRect.height);
+                    } else if (shouldCalculateVisibilityPercentage && adjustedRect.left < 0 && adjustedRect.right > 0) {
+                        visibilityPercentage =
+                            Math.floor(100 * adjustedRect.right / adjustedRect.width);
+                    } else if (shouldCalculateVisibilityPercentage && adjustedRect.left < 0 && adjustedRect.right > 0) {
+                        visibilityPercentage =
+                            Math.floor(100 * adjustedRect.right / adjustedRect.width);
                     } else {
                         visibilityPercentage = 100;
                     }

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -372,13 +372,13 @@ var CfiNavigationLogic = function (options) {
 
             if (isVwm) {
                 var topOffset = firstRectangle.top;
-                pageIndex = Math.floor(topOffset / frameDimensions.height);
+                pageIndex = Math.round(topOffset / frameDimensions.height);
             } else {
                 var leftOffset = firstRectangle.left;
                 if (isRtl) {
                     leftOffset = (columnFullWidth * (options.paginationInfo ? options.paginationInfo.visibleColumnCount : 1)) - leftOffset;
                 }
-                pageIndex = Math.floor(leftOffset / columnFullWidth);
+                pageIndex = Math.round(leftOffset / columnFullWidth);
             }
 
             return pageIndex;

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -520,7 +520,9 @@ var CfiNavigationLogic = function (options) {
                 width: textRect.right - textRect.left,
                 height: textRect.bottom - textRect.top
             };
-            offsetRectangle(plainRectObject, leftOffset, topOffset);
+            if (leftOffset && topOffset) {
+                offsetRectangle(plainRectObject, leftOffset, topOffset);
+            }
             return plainRectObject;
         }
 
@@ -896,10 +898,18 @@ var CfiNavigationLogic = function (options) {
         };
 
         function generateCfiFromDomRange(range) {
-            return EPUBcfi.generateRangeComponent(
-                range.startContainer, range.startOffset,
-                range.endContainer, range.endOffset,
-                self.getClassBlacklist(), self.getElementBlacklist(), self.getIdBlacklist());
+            if (range.collapsed && range.startContainer.nodeType === Node.TEXT_NODE) {
+                return EPUBcfi.generateCharacterOffsetCFIComponent(
+                    range.startContainer, range.startOffset,
+                    ['cfi-marker'], [], ["MathJax_Message", "MathJax_SVG_Hidden"]);
+            } else if (range.collapsed) {
+                return self.getCfiForElement(range.startContainer);
+            } else {
+                return EPUBcfi.generateRangeComponent(
+                    range.startContainer, range.startOffset,
+                    range.endContainer, range.endOffset,
+                    self.getClassBlacklist(), self.getElementBlacklist(), self.getIdBlacklist());
+            }
         }
 
         function getRangeTargetNodes(rangeCfi) {

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -26,31 +26,31 @@
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /**
- * CFI navigation helper class
- *
- * @param options Additional settings for NavigationLogic object
- *      - paginationInfo            Layout details, used by clientRect-based geometry
- *      - visibleContentOffsets     Function that returns offsets. If supplied it is used instead of the inferred offsets
- *      - frameDimensions           Function that returns an object with width and height properties. Needs to be set.
- *      - $iframe                   Iframe reference, and needs to be set.
- * @constructor
- */
+* CFI navigation helper class
+*
+* @param options Additional settings for NavigationLogic object
+*      - paginationInfo            Layout details, used by clientRect-based geometry
+*      - visibleContentOffsets     Function that returns offsets. If supplied it is used instead of the inferred offsets
+*      - frameDimensions           Function that returns an object with width and height properties. Needs to be set.
+*      - $iframe                   Iframe reference, and needs to be set.
+* @constructor
+*/
 define(["jquery", "underscore", "../helpers", 'readium_cfi_js'], function($, _, Helpers, epubCfi) {
 
-var CfiNavigationLogic = function(options) {
+var CfiNavigationLogic = function (options) {
 
     var self = this;
     options = options || {};
 
     var debugMode = ReadiumSDK.DEBUG_MODE;
 
-    this.getRootElement = function() {
+    this.getRootElement = function () {
 
         return options.$iframe[0].contentDocument.documentElement;
     };
-    
+
     this.getBodyElement = function () {
-        
+
         // In SVG documents the root element can be considered the body.
         return this.getRootDocument().body || this.getRootElement();
     };
@@ -75,17 +75,23 @@ var CfiNavigationLogic = function(options) {
         return self.getRootDocument().createRange();
     }
 
-    function getNodeClientRect(node) {
-        var range = createRange();
-        range.selectNode(node);
-        return normalizeRectangle(range.getBoundingClientRect(),0,0);
+    function createRangeFromNode(textnode) {
+        var documentRange = createRange();
+        documentRange.selectNodeContents(textnode);
+        return documentRange;
     }
 
+    function getNodeClientRect(node) {
+            var range = createRange();
+            range.selectNode(node);
+            return normalizeRectangle(range.getBoundingClientRect(), 0, 0);
+        }
+
     function getNodeContentsClientRect(node) {
-        var range = createRange();
-        range.selectNodeContents(node);
-        return normalizeRectangle(range.getBoundingClientRect(),0,0);
-    }
+            var range = createRange();
+            range.selectNodeContents(node);
+            return normalizeRectangle(range.getBoundingClientRect(), 0, 0);
+        }
 
     function getNodeRangeClientRect(startNode, startOffset, endNode, endOffset) {
         var range = createRange();
@@ -95,12 +101,12 @@ var CfiNavigationLogic = function(options) {
         } else if (endNode.nodeType === Node.TEXT_NODE) {
             range.setEnd(endNode, endOffset ? endOffset : 0);
         }
-        return normalizeRectangle(range.getBoundingClientRect(),0,0);
+        return normalizeRectangle(range.getBoundingClientRect(), 0, 0);
     }
 
     function getNodeClientRectList(node, visibleContentOffsets) {
         visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
-        
+
         var range = createRange();
         range.selectNode(node);
         return getRangeClientRectList(range, visibleContentOffsets);
@@ -119,7 +125,7 @@ var CfiNavigationLogic = function(options) {
         if (options.frameDimensionsGetter) {
             return options.frameDimensionsGetter();
         }
-        
+
         console.error('CfiNavigationLogic: No frame dimensions specified!');
         return null;
     }
@@ -187,48 +193,54 @@ var CfiNavigationLogic = function(options) {
 
     }
 
-    /**
-     * @private
-     * Retrieves _current_ full width of a column (including its gap)
-     *
-     * @returns {number} Full width of a column in pixels
-     */
-    function getColumnFullWidth() {
+        /**
+         * @private
+         * Retrieves _current_ full width of a column (including its gap)
+         *
+         * @returns {number} Full width of a column in pixels
+         */
+        function getColumnFullWidth() {
 
         if (!options.paginationInfo || isVerticalWritingMode())
         {
-            return options.$iframe.width();
+                return options.$iframe.width();
+            }
+
+            return options.paginationInfo.columnWidth + options.paginationInfo.columnGap;
         }
 
-        return options.paginationInfo.columnWidth + options.paginationInfo.columnGap;
-    }
+        /**
+         * @private
+         *
+         * Retrieves _current_ offset of a viewport
+         * (relational to the beginning of the chapter)
+         *
+         * @returns {Object}
+         */
+        function getVisibleContentOffsets() {
+            if (options.visibleContentOffsetsGetter) {
+                return options.visibleContentOffsetsGetter();
+            }
 
-    /**
-     * @private
-     *
-     * Retrieves _current_ offset of a viewport
-     * (relational to the beginning of the chapter)
-     *
-     * @returns {Object}
-     */
-    function getVisibleContentOffsets() {
-        if (options.visibleContentOffsetsGetter) {
-            return options.visibleContentOffsetsGetter();
+            if (isVerticalWritingMode() && options.paginationOffsetsGetter) {
+                return options.paginationOffsetsGetter();
+            }
+
+            return {
+                top: 0,
+                left: 0
+            };
         }
 
-        if (isVerticalWritingMode() && options.paginationOffsetsGetter) {
-            return options.paginationOffsetsGetter();
-        }
+        function getPaginationOffsets() {
+            if (options.paginationOffsetsGetter) {
+                return options.paginationOffsetsGetter();
+            }
 
-        return {
-            top: 0,
-            left: 0
-        };
-    }
-
-    function getPaginationOffsets() {
-        if (options.paginationOffsetsGetter) {
-            return options.paginationOffsetsGetter();
+            return {
+                top: 0,
+                left: 0
+            };
         }
         
         // CAUSES REGRESSION BUGS !! TODO FIXME
@@ -241,1094 +253,1035 @@ var CfiNavigationLogic = function(options) {
         //     };
         // }
 
-        return {
-            top: 0,
-            left: 0
-        };
-    }
+        /**
+         * New (rectangle-based) algorithm, useful in multi-column layouts
+         *
+         * Note: the second param (props) is ignored intentionally
+         * (no need to use those in normalization)
+         *
+         * @param {jQuery} $element
+         * @param {boolean} shouldCalculateVisibilityPercentage
+         * @param {Object} [visibleContentOffsets]
+         * @param {Object} [frameDimensions]
+         * @returns {number|null}
+         *      0 for non-visible elements,
+         *      0 < n <= 100 for visible elements
+         *      (will just give 100, if `shouldCalculateVisibilityPercentage` => false)
+         *      null for elements with display:none
+         */
+        function checkVisibilityByRectangles($element, shouldCalculateVisibilityPercentage, visibleContentOffsets, frameDimensions) {
+            visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
+            frameDimensions = frameDimensions || getFrameDimensions();
 
-    /**
-     * New (rectangle-based) algorithm, useful in multi-column layouts
-     *
-     * Note: the second param (props) is ignored intentionally
-     * (no need to use those in normalization)
-     *
-     * @param {jQuery} $element
-     * @param {boolean} shouldCalculateVisibilityPercentage
-     * @param {Object} [visibleContentOffsets]
-     * @param {Object} [frameDimensions]
-     * @returns {number|null}
-     *      0 for non-visible elements,
-     *      0 < n <= 100 for visible elements
-     *      (will just give 100, if `shouldCalculateVisibilityPercentage` => false)
-     *      null for elements with display:none
-     */
-    function checkVisibilityByRectangles($element, shouldCalculateVisibilityPercentage, visibleContentOffsets, frameDimensions) {
-        visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
-        frameDimensions = frameDimensions || getFrameDimensions();
+            var clientRectangles = getNormalizedRectangles($element, visibleContentOffsets);
+            if (clientRectangles.length === 0) { // elements with display:none, etc.
+                return null;
+            }
 
-        var clientRectangles = getNormalizedRectangles($element, visibleContentOffsets);
-        if (clientRectangles.length === 0) { // elements with display:none, etc.
-            return null;
-        }
+            var visibilityPercentage = 0;
 
-        var visibilityPercentage = 0;
+            if (clientRectangles.length === 1) {
+                var adjustedRect = clientRectangles[0];
 
-        if (clientRectangles.length === 1) {
-            var adjustedRect = clientRectangles[0];
-            
-            if (isPaginatedView()) {
-                if (adjustedRect.bottom > frameDimensions.height || adjustedRect.top < 0) {
-                    // because of webkit inconsistency, that single rectangle should be adjusted
-                    // until it hits the end OR will be based on the FIRST column that is visible
-                    adjustRectangle(adjustedRect, true, frameDimensions);
+                if (isPaginatedView()) {
+                    if (adjustedRect.bottom > frameDimensions.height || adjustedRect.top < 0) {
+                        // because of webkit inconsistency, that single rectangle should be adjusted
+                        // until it hits the end OR will be based on the FIRST column that is visible
+                        adjustRectangle(adjustedRect, true, frameDimensions);
+                    }
+                }
+
+                if (isRectVisible(adjustedRect, false, frameDimensions)) {
+                    //it might still be partially visible in webkit
+                    if (shouldCalculateVisibilityPercentage && adjustedRect.top < 0) {
+                        visibilityPercentage =
+                            Math.floor(100 * (adjustedRect.height + adjustedRect.top) / adjustedRect.height);
+                    } else if (shouldCalculateVisibilityPercentage && adjustedRect.bottom > frameDimensions.height) {
+                        visibilityPercentage =
+                            Math.floor(100 * (frameDimensions.height - adjustedRect.top) / adjustedRect.height);
+                    } else {
+                        visibilityPercentage = 100;
+                    }
+                }
+            } else {
+                // for an element split between several CSS columns,z
+                // both Firefox and IE produce as many client rectangles;
+                // each of those should be checked
+                for (var i = 0, l = clientRectangles.length; i < l; ++i) {
+                    if (isRectVisible(clientRectangles[i], false, frameDimensions)) {
+                        visibilityPercentage = shouldCalculateVisibilityPercentage
+                            ? measureVisibilityPercentageByRectangles(clientRectangles, i)
+                            : 100;
+                        break;
+                    }
                 }
             }
 
-            if (isRectVisible(adjustedRect, false, frameDimensions)) {
-                //it might still be partially visible in webkit
-                if (shouldCalculateVisibilityPercentage && adjustedRect.top < 0) {
-                    visibilityPercentage =
-                        Math.floor(100 * (adjustedRect.height + adjustedRect.top) / adjustedRect.height);
-                } else if (shouldCalculateVisibilityPercentage && adjustedRect.bottom > frameDimensions.height) {
-                    visibilityPercentage =
-                        Math.floor(100 * (frameDimensions.height - adjustedRect.top) / adjustedRect.height);
-                } else {
-                    visibilityPercentage = 100;
-                }
-            }
-        } else {
-            // for an element split between several CSS columns,z
-            // both Firefox and IE produce as many client rectangles;
-            // each of those should be checked
-            for (var i = 0, l = clientRectangles.length; i < l; ++i) {
-                if (isRectVisible(clientRectangles[i], false, frameDimensions)) {
-                    visibilityPercentage = shouldCalculateVisibilityPercentage
-                        ? measureVisibilityPercentageByRectangles(clientRectangles, i)
-                        : 100;
-                    break;
-                }
-            }
+            return visibilityPercentage;
         }
 
-        return visibilityPercentage;
-    }
+        /**
+         * Finds a page index (0-based) for a specific element.
+         * Calculations are based on rectangles retrieved with getClientRects() method.
+         *
+         * @param {jQuery} $element
+         * @returns {number|null}
+         */
+        function findPageByRectangles($element) {
 
-    /**
-     * Finds a page index (0-based) for a specific element.
-     * Calculations are based on rectangles retrieved with getClientRects() method.
-     *
-     * @param {jQuery} $element
-     * @returns {number|null}
-     */
-    function findPageByRectangles($element) {
+            var visibleContentOffsets = getVisibleContentOffsets();
 
-        var visibleContentOffsets = getVisibleContentOffsets();
-        //////////////////////
-        // ABOVE CAUSES REGRESSION BUGS !! TODO FIXME
-        // https://github.com/readium/readium-shared-js/issues/384#issuecomment-305145129
-        if (options.visibleContentOffsets) {
-            visibleContentOffsets = options.visibleContentOffsets();
+            var clientRectangles = getNormalizedRectangles($element, visibleContentOffsets);
+            if (clientRectangles.length === 0) { // elements with display:none, etc.
+                return null;
+            }
+
+            return calculatePageIndexByRectangles(clientRectangles);
         }
-        if (isVerticalWritingMode()) {
-            visibleContentOffsets = {
-                top: (options.paginationInfo ? options.paginationInfo.pageOffset : 0),
-                left: 0
+
+        /**
+         * @private
+         * Calculate a page index (0-based) for given client rectangles.
+         *
+         * @param {object[]} clientRectangles
+         * @param {object} [frameDimensions]
+         * @param {number} [columnFullWidth]
+         * @returns {number|null}
+         */
+        function calculatePageIndexByRectangles(clientRectangles, frameDimensions, columnFullWidth) {
+            var isRtl = isPageProgressionRightToLeft();
+            var isVwm = isVerticalWritingMode();
+            columnFullWidth = columnFullWidth || getColumnFullWidth();
+            frameDimensions = frameDimensions || getFrameDimensions();
+
+            var firstRectangle = _.first(clientRectangles);
+            if (clientRectangles.length === 1) {
+                adjustRectangle(firstRectangle, false, frameDimensions, columnFullWidth, isRtl, isVwm);
+            }
+
+            var pageIndex;
+
+            if (isVwm) {
+                var topOffset = firstRectangle.top;
+                pageIndex = Math.floor(topOffset / frameDimensions.height);
+            } else {
+                var leftOffset = firstRectangle.left;
+                if (isRtl) {
+                    leftOffset = (columnFullWidth * (options.paginationInfo ? options.paginationInfo.visibleColumnCount : 1)) - leftOffset;
+                }
+                pageIndex = Math.floor(leftOffset / columnFullWidth);
+            }
+
+            return pageIndex;
+        }
+
+        /**
+         * Finds a page index (0-based) for a specific client rectangle.
+         * Calculations are based on viewport dimensions, offsets, and rectangle coordinates
+         *
+         * @param {ClientRect} clientRectangle
+         * @param {Object} [visibleContentOffsets]
+         * @param {Object} [frameDimensions]
+         * @returns {number|null}
+         */
+        function findPageBySingleRectangle(clientRectangle, visibleContentOffsets, frameDimensions) {
+            visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
+            frameDimensions = frameDimensions || getFrameDimensions();
+
+            var normalizedRectangle = normalizeRectangle(
+                clientRectangle, visibleContentOffsets.left, visibleContentOffsets.top);
+
+            return calculatePageIndexByRectangles([normalizedRectangle], frameDimensions);
+        }
+
+        /**
+         * @private
+         * Calculates the visibility offset percentage based on ClientRect dimensions
+         *
+         * @param {Array} clientRectangles (should already be normalized)
+         * @param {number} firstVisibleRectIndex
+         * @returns {number} - visibility percentage (0 < n <= 100)
+         */
+        function measureVisibilityPercentageByRectangles(clientRectangles, firstVisibleRectIndex) {
+
+            var heightTotal = 0;
+            var heightVisible = 0;
+
+            if (clientRectangles.length > 1) {
+                _.each(clientRectangles, function (rect, index) {
+                    heightTotal += rect.height;
+                    if (index >= firstVisibleRectIndex) {
+                        // in this case, all the rectangles after the first visible
+                        // should be counted as visible
+                        heightVisible += rect.height;
+                    }
+                });
+            }
+            else {
+                // should already be normalized and adjusted
+                heightTotal = clientRectangles[0].height;
+                heightVisible = clientRectangles[0].height - Math.max(
+                    0, -clientRectangles[0].top);
+            }
+            return heightVisible === heightTotal
+                ? 100 // trivial case: element is 100% visible
+                : Math.floor(100 * heightVisible / heightTotal);
+        }
+
+        /**
+         * @private
+         * Retrieves the position of $element in multi-column layout
+         *
+         * @param {jQuery} $el
+         * @param {Object} [visibleContentOffsets]
+         * @returns {Object[]}
+         */
+        function getNormalizedRectangles($el, visibleContentOffsets) {
+
+            visibleContentOffsets = visibleContentOffsets || {};
+            var leftOffset = visibleContentOffsets.left || 0;
+            var topOffset = visibleContentOffsets.top || 0;
+
+            var isTextNode = ($el[0].nodeType === Node.TEXT_NODE);
+            var clientRectList;
+
+            if (isTextNode) {
+                var range = createRange();
+                range.selectNode($el[0]);
+                //noinspection JSUnresolvedFunction
+                clientRectList = range.getClientRects();
+            } else {
+                //noinspection JSUnresolvedFunction
+                clientRectList = $el[0].getClientRects();
+            }
+
+            // all the separate rectangles (for detecting position of the element
+            // split between several columns)
+            var clientRectangles = [];
+            for (var i = 0, l = clientRectList.length; i < l; ++i) {
+                if (clientRectList[i].height > 0) {
+                    // Firefox sometimes gets it wrong,
+                    // adding literally empty (height = 0) client rectangle preceding the real one,
+                    // that empty client rectanle shouldn't be retrieved
+                    clientRectangles.push(
+                        normalizeRectangle(clientRectList[i], leftOffset, topOffset));
+                }
+            }
+
+            return clientRectangles;
+        }
+
+        function getNormalizedBoundingRect($el, visibleContentOffsets) {
+            visibleContentOffsets = visibleContentOffsets || {};
+            var leftOffset = visibleContentOffsets.left || 0;
+            var topOffset = visibleContentOffsets.top || 0;
+
+            var isTextNode = ($el[0].nodeType === Node.TEXT_NODE);
+            var boundingClientRect;
+
+            if (isTextNode) {
+                var range = createRange();
+                range.selectNode($el[0]);
+                boundingClientRect = range.getBoundingClientRect();
+            } else {
+                boundingClientRect = $el[0].getBoundingClientRect();
+            }
+
+            // union of all rectangles wrapping the element
+            return normalizeRectangle(boundingClientRect, leftOffset, topOffset);
+        }
+
+        /**
+         * @private
+         * Converts TextRectangle object into a plain object,
+         * taking content offsets (=scrolls, position shifts etc.) into account
+         *
+         * @param {Object} textRect
+         * @param {number} leftOffset
+         * @param {number} topOffset
+         * @returns {Object}
+         */
+        function normalizeRectangle(textRect, leftOffset, topOffset) {
+
+            var plainRectObject = {
+                left: textRect.left,
+                right: textRect.right,
+                top: textRect.top,
+                bottom: textRect.bottom,
+                width: textRect.right - textRect.left,
+                height: textRect.bottom - textRect.top
             };
-        }
-        else { // THIS IS ENABLED ONLY FOR findPageByRectangles(), to fix the pageIndex computation. TODO FIXME!
-            visibleContentOffsets = {
-                top: 0,
-                left: (options.paginationInfo ? options.paginationInfo.pageOffset : 0)
-                //* (isPageProgressionRightToLeft() ? -1 : 1)
-            };
-        }
-        //////////////////////
-
-        var clientRectangles = getNormalizedRectangles($element, visibleContentOffsets);
-        if (clientRectangles.length === 0) { // elements with display:none, etc.
-            return null;
+            offsetRectangle(plainRectObject, leftOffset, topOffset);
+            return plainRectObject;
         }
 
-        return calculatePageIndexByRectangles(clientRectangles);
-    }
+        /**
+         * @private
+         * Offsets plain object (which represents a TextRectangle).
+         *
+         * @param {Object} rect
+         * @param {number} leftOffset
+         * @param {number} topOffset
+         */
+        function offsetRectangle(rect, leftOffset, topOffset) {
 
-    /**
-     * @private
-     * Calculate a page index (0-based) for given client rectangles.
-     *
-     * @param {object[]} clientRectangles
-     * @param {object} [frameDimensions]
-     * @param {number} [columnFullWidth]
-     * @returns {number|null}
-     */
-    function calculatePageIndexByRectangles(clientRectangles, frameDimensions, columnFullWidth) {
-        var isRtl = isPageProgressionRightToLeft();
-        var isVwm = isVerticalWritingMode();
-        columnFullWidth = columnFullWidth || getColumnFullWidth();
-        frameDimensions = frameDimensions || getFrameDimensions();
-
-        var firstRectangle = _.first(clientRectangles);
-        if (clientRectangles.length === 1) {
-            adjustRectangle(firstRectangle, false, frameDimensions, columnFullWidth, isRtl, isVwm);
+            rect.left += leftOffset;
+            rect.right += leftOffset;
+            rect.top += topOffset;
+            rect.bottom += topOffset;
         }
 
-        var pageIndex;
+        /**
+         * @private
+         *
+         * When element is spilled over two or more columns,
+         * most of the time Webkit-based browsers
+         * still assign a single clientRectangle to it, setting its `top` property to negative value
+         * (so it looks like it's rendered based on the second column)
+         * Alas, sometimes they decide to continue the leftmost column - from _below_ its real height.
+         * In this case, `bottom` property is actually greater than element's height and had to be adjusted accordingly.
+         *
+         * Ugh.
+         *
+         * @param {Object} rect
+         * @param {boolean} [shouldLookForFirstVisibleColumn]
+         *      If set, there'll be two-phase adjustment
+         *      (to align a rectangle with a viewport)
+         * @param {Object} [frameDimensions]
+         * @param {number} [columnFullWidth]
+         * @param {boolean} [isRtl]
+         * @param {boolean} [isVwm]               isVerticalWritingMode
+         */
+        function adjustRectangle(rect, shouldLookForFirstVisibleColumn, frameDimensions, columnFullWidth, isRtl, isVwm) {
 
-        if (isVwm) {
-            var topOffset = firstRectangle.top;
-            pageIndex = Math.floor(topOffset / frameDimensions.height);
-        } else {
-            var leftOffset = firstRectangle.left;
+            frameDimensions = frameDimensions || getFrameDimensions();
+            columnFullWidth = columnFullWidth || getColumnFullWidth();
+            isRtl = isRtl || isPageProgressionRightToLeft();
+            isVwm = isVwm || isVerticalWritingMode();
+
+            // Rectangle adjustment is not needed in VWM since it does not deal with columns
+            if (isVwm) {
+                return;
+            }
+
             if (isRtl) {
-                leftOffset = (columnFullWidth * (options.paginationInfo ? options.paginationInfo.visibleColumnCount : 1)) - leftOffset;
-            }
-            pageIndex = Math.floor(leftOffset / columnFullWidth);
-        }
-
-        return pageIndex;
-    }
-
-    /**
-     * Finds a page index (0-based) for a specific client rectangle.
-     * Calculations are based on viewport dimensions, offsets, and rectangle coordinates
-     *
-     * @param {ClientRect} clientRectangle
-     * @param {Object} [visibleContentOffsets]
-     * @param {Object} [frameDimensions]
-     * @returns {number|null}
-     */
-    function findPageBySingleRectangle(clientRectangle, visibleContentOffsets, frameDimensions) {
-        visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
-        frameDimensions = frameDimensions || getFrameDimensions();
-        
-        var normalizedRectangle = normalizeRectangle(
-            clientRectangle, visibleContentOffsets.left, visibleContentOffsets.top);
-
-        return calculatePageIndexByRectangles([normalizedRectangle], frameDimensions);
-    }
-
-    /**
-     * @private
-     * Calculates the visibility offset percentage based on ClientRect dimensions
-     *
-     * @param {Array} clientRectangles (should already be normalized)
-     * @param {number} firstVisibleRectIndex
-     * @returns {number} - visibility percentage (0 < n <= 100)
-     */
-    function measureVisibilityPercentageByRectangles(clientRectangles, firstVisibleRectIndex) {
-
-        var heightTotal = 0;
-        var heightVisible = 0;
-
-        if (clientRectangles.length > 1) {
-            _.each(clientRectangles, function (rect, index) {
-                heightTotal += rect.height;
-                if (index >= firstVisibleRectIndex) {
-                    // in this case, all the rectangles after the first visible
-                    // should be counted as visible
-                    heightVisible += rect.height;
-                }
-            });
-        }
-        else {
-            // should already be normalized and adjusted
-            heightTotal = clientRectangles[0].height;
-            heightVisible = clientRectangles[0].height - Math.max(
-                0, -clientRectangles[0].top);
-        }
-        return heightVisible === heightTotal
-            ? 100 // trivial case: element is 100% visible
-            : Math.floor(100 * heightVisible / heightTotal);
-    }
-
-    /**
-     * @private
-     * Retrieves the position of $element in multi-column layout
-     *
-     * @param {jQuery} $el
-     * @param {Object} [visibleContentOffsets]
-     * @returns {Object[]}
-     */
-    function getNormalizedRectangles($el, visibleContentOffsets) {
-
-        visibleContentOffsets = visibleContentOffsets || {};
-        var leftOffset = visibleContentOffsets.left || 0;
-        var topOffset = visibleContentOffsets.top || 0;
-
-        var isTextNode = ($el[0].nodeType === Node.TEXT_NODE);
-        var clientRectList;
-
-        if (isTextNode) {
-            var range = createRange();
-            range.selectNode($el[0]);
-            //noinspection JSUnresolvedFunction
-            clientRectList = range.getClientRects();
-        } else {
-            //noinspection JSUnresolvedFunction
-            clientRectList = $el[0].getClientRects();
-        }
-
-        // all the separate rectangles (for detecting position of the element
-        // split between several columns)
-        var clientRectangles = [];
-        for (var i = 0, l = clientRectList.length; i < l; ++i) {
-            if (clientRectList[i].height > 0) {
-                // Firefox sometimes gets it wrong,
-                // adding literally empty (height = 0) client rectangle preceding the real one,
-                // that empty client rectanle shouldn't be retrieved
-                clientRectangles.push(
-                    normalizeRectangle(clientRectList[i], leftOffset, topOffset));
-            }
-        }
-
-        return clientRectangles;
-    }
-
-    function getNormalizedBoundingRect($el, visibleContentOffsets) {
-        visibleContentOffsets = visibleContentOffsets || {};
-        var leftOffset = visibleContentOffsets.left || 0;
-        var topOffset = visibleContentOffsets.top || 0;
-
-        var isTextNode = ($el[0].nodeType === Node.TEXT_NODE);
-        var boundingClientRect;
-
-        if (isTextNode) {
-            var range = createRange();
-            range.selectNode($el[0]);
-            boundingClientRect = range.getBoundingClientRect();
-        } else {
-            boundingClientRect = $el[0].getBoundingClientRect();
-        }
-
-        // union of all rectangles wrapping the element
-        return normalizeRectangle(boundingClientRect, leftOffset, topOffset);
-    }
-
-    /**
-     * @private
-     * Converts TextRectangle object into a plain object,
-     * taking content offsets (=scrolls, position shifts etc.) into account
-     *
-     * @param {Object} textRect
-     * @param {number} leftOffset
-     * @param {number} topOffset
-     * @returns {Object}
-     */
-    function normalizeRectangle(textRect, leftOffset, topOffset) {
-
-        var plainRectObject = {
-            left: textRect.left,
-            right: textRect.right,
-            top: textRect.top,
-            bottom: textRect.bottom,
-            width: textRect.right - textRect.left,
-            height: textRect.bottom - textRect.top
-        };
-        offsetRectangle(plainRectObject, leftOffset, topOffset);
-        return plainRectObject;
-    }
-
-    /**
-     * @private
-     * Offsets plain object (which represents a TextRectangle).
-     *
-     * @param {Object} rect
-     * @param {number} leftOffset
-     * @param {number} topOffset
-     */
-    function offsetRectangle(rect, leftOffset, topOffset) {
-
-        rect.left += leftOffset;
-        rect.right += leftOffset;
-        rect.top += topOffset;
-        rect.bottom += topOffset;
-    }
-
-    /**
-     * @private
-     *
-     * When element is spilled over two or more columns,
-     * most of the time Webkit-based browsers
-     * still assign a single clientRectangle to it, setting its `top` property to negative value
-     * (so it looks like it's rendered based on the second column)
-     * Alas, sometimes they decide to continue the leftmost column - from _below_ its real height.
-     * In this case, `bottom` property is actually greater than element's height and had to be adjusted accordingly.
-     *
-     * Ugh.
-     *
-     * @param {Object} rect
-     * @param {boolean} [shouldLookForFirstVisibleColumn]
-     *      If set, there'll be two-phase adjustment
-     *      (to align a rectangle with a viewport)
-     * @param {Object} [frameDimensions]
-     * @param {number} [columnFullWidth]
-     * @param {boolean} [isRtl]
-     * @param {boolean} [isVwm]               isVerticalWritingMode
-     */
-    function adjustRectangle(rect, shouldLookForFirstVisibleColumn, frameDimensions, columnFullWidth, isRtl, isVwm) {
-
-        frameDimensions = frameDimensions || getFrameDimensions();
-        columnFullWidth = columnFullWidth || getColumnFullWidth();
-        isRtl = isRtl || isPageProgressionRightToLeft();
-        isVwm = isVwm || isVerticalWritingMode();
-
-        // Rectangle adjustment is not needed in VWM since it does not deal with columns
-        if (isVwm) {
-            return;
-        }
-
-        if (isRtl) {
-            columnFullWidth *= -1; // horizontal shifts are reverted in RTL mode
-        }
-
-        // first we go left/right (rebasing onto the very first column available)
-        while (rect.top < 0) {
-            offsetRectangle(rect, -columnFullWidth, frameDimensions.height);
-        }
-
-        // ... then, if necessary (for visibility offset checks),
-        // each column is tried again (now in reverse order)
-        // the loop will be stopped when the column is aligned with a viewport
-        // (i.e., is the first visible one).
-        if (shouldLookForFirstVisibleColumn) {
-            while (rect.bottom >= frameDimensions.height) {
-                if (isRectVisible(rect, false, frameDimensions)) {
-                    break;
-                }
-                offsetRectangle(rect, columnFullWidth, -frameDimensions.height);
-            }
-        }
-    }
-
-    this.getCfiForElement = function (element) {
-        var cfi = EPUBcfi.Generator.generateElementCFIComponent(element,
-            this.getClassBlacklist(),
-            this.getElementBlacklist(),
-            this.getIdBlacklist());
-
-        if (cfi[0] == "!") {
-            cfi = cfi.substring(1);
-        }
-        return cfi;
-    };
-
-    this.getVisibleCfiFromPoint = function (x, y, precisePoint) {
-        var document = self.getRootDocument();
-        var firstVisibleCaretRange = getCaretRangeFromPoint(x, y, document);
-        var elementFromPoint = document.elementFromPoint(x, y);
-        var invalidElementFromPoint = !elementFromPoint || elementFromPoint === document.documentElement;
-
-        if (precisePoint) {
-            if (!elementFromPoint || invalidElementFromPoint) {
-                return null;
-            }
-            var testRect = getNodeContentsClientRect(elementFromPoint);
-            if (!isRectVisible(testRect, false)) {
-                return null;
-            }
-            if ((x < testRect.left || x > testRect.right) || (y < testRect.top || y > testRect.bottom)) {
-                return null;
-            }
-        }
-
-        if (!firstVisibleCaretRange) {
-            if (invalidElementFromPoint) {
-                console.error("Could not generate CFI no visible element on page");
-                return null;
-            }
-            firstVisibleCaretRange = createRange();
-            firstVisibleCaretRange.selectNode(elementFromPoint);
-        }
-
-        var range = firstVisibleCaretRange;
-        var cfi;
-        //if we get a text node we need to get an approximate range for the first visible character offsets.
-        var node = range.startContainer;
-        var startOffset, endOffset;
-        if (node.nodeType === Node.TEXT_NODE) {
-            if (precisePoint && node.parentNode !== elementFromPoint) {
-                return null;
-            }
-            if (node.length === 1 && range.startOffset === 1) {
-                startOffset = 0;
-                endOffset = 1;
-            } else if (range.startOffset === node.length) {
-                startOffset = range.startOffset - 1;
-                endOffset = range.startOffset;
-            } else {
-                startOffset = range.startOffset;
-                endOffset = range.startOffset + 1;
-            }
-            var wrappedRange = {
-                startContainer: node,
-                endContainer: node,
-                startOffset: startOffset,
-                endOffset: endOffset,
-                commonAncestorContainer: range.commonAncestorContainer
-            };
-
-            if (debugMode) {
-                drawDebugOverlayFromDomRange(wrappedRange);
+                columnFullWidth *= -1; // horizontal shifts are reverted in RTL mode
             }
 
-            cfi = generateCfiFromDomRange(wrappedRange);
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-            node =
-                range.startContainer.childNodes[range.startOffset] ||
-                range.startContainer.childNodes[0] ||
-                range.startContainer;
-            if (precisePoint && node !== elementFromPoint) {
-                return null;
+            // first we go left/right (rebasing onto the very first column available)
+            while (rect.top < 0) {
+                offsetRectangle(rect, -columnFullWidth, frameDimensions.height);
             }
 
-            if (node.nodeType !== Node.ELEMENT_NODE) {
-                cfi = generateCfiFromDomRange(range);
-            } else {
-                cfi = self.getCfiForElement(node);
-            }
-        } else {
-            if (precisePoint && node !== elementFromPoint) {
-                return null;
-            }
-
-            cfi = self.getCfiForElement(elementFromPoint);
-        }
-
-        //This should not happen but if it does print some output, just in case
-        if (cfi && cfi.indexOf('NaN') !== -1) {
-            console.log('Did not generate a valid CFI:' + cfi);
-            return undefined;
-        }
-
-        return cfi;
-    };
-
-    this.getRangeCfiFromPoints = function(startX, startY, endX, endY) {
-        var document = self.getRootDocument();
-        var start = getCaretRangeFromPoint(startX, startY, document),
-            end = getCaretRangeFromPoint(endX, endY, document),
-            range = createRange();
-        range.setStart(start.startContainer, start.startOffset);
-        range.setEnd(end.startContainer, end.startOffset);
-        // if we're looking at a text node create a nice range (n, n+1)
-        if (start.startContainer === start.endContainer && start.startContainer.nodeType === Node.TEXT_NODE && end.startContainer.length > end.startOffset+1) {
-            range.setEnd(end.startContainer, end.startOffset+1);
-        }
-        return generateCfiFromDomRange(range);
-    };
-
-    function getTextNodeRectCornerPairs(rect) {
-        //
-        //    top left             top right
-        //    ╲                   ╱
-        //  ── ▒T▒E▒X▒T▒ ▒R▒E▒C▒T▒ ──
-        //
-        // top left corner & top right corner
-        // but for y coord use the mid point between top and bottom
-
-        if (isVerticalWritingMode()) {
-            var x = rect.right - (rect.width / 2);
-            return [{x: x, y: rect.top}, {x: x, y: rect.bottom}];
-        } else {
-            var y = rect.top + (rect.height / 2);
-            var result = [{x: rect.left, y: y}, {x: rect.right, y: y}];
-            return isPageProgressionRightToLeft() ? result.reverse() : result;
-        }
-    }
-
-    var DEBUG = false;
-
-    function getVisibleTextRangeOffsetsSelectedByFunc(textNode, pickerFunc, visibleContentOffsets, frameDimensions) {
-        visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
-        
-        var textNodeFragments = getNodeClientRectList(textNode, visibleContentOffsets);
-
-        var visibleFragments = _.filter(textNodeFragments, function (rect) {
-            return isRectVisible(rect, false, frameDimensions);
-        });
-
-        var fragment = pickerFunc(visibleFragments);
-        if (!fragment) {
-            //no visible fragment, empty text node?
-            return null;
-        }
-        var fragmentCorner = pickerFunc(getTextNodeRectCornerPairs(fragment));
-        // Reverse taking into account of visible content offsets
-        fragmentCorner.x -= visibleContentOffsets.left;
-        fragmentCorner.y -= visibleContentOffsets.top;
-        
-        var caretRange = getCaretRangeFromPoint(fragmentCorner.x, fragmentCorner.y);
-
-        // Workaround for inconsistencies with the caretRangeFromPoint IE TextRange based shim.
-        if (caretRange && caretRange.startContainer !== textNode && caretRange.startContainer === textNode.parentNode) {
-            if (DEBUG) console.log('ieTextRangeWorkaround needed');
-            var startOrEnd = pickerFunc([0, 1]);
-
-            // #1
-            if (caretRange.startOffset === caretRange.endOffset) {
-                var checkNode = caretRange.startContainer.childNodes[Math.max(caretRange.startOffset - 1, 0)];
-                if (checkNode === textNode) {
-                    caretRange = {
-                        startContainer: textNode,
-                        endContainer: textNode,
-                        startOffset: startOrEnd === 0 ? 0 : textNode.nodeValue.length
-                    };
-                    if (DEBUG) console.log('ieTextRangeWorkaround #1:', caretRange);
+            // ... then, if necessary (for visifindTextRangeOffsetRecursivelity offset checks),
+            // each column is tried again (now in reverse order)
+            // the loop will be stopped when the column is aligned with a viewport
+            // (i.e., is the first visible one).
+            if (shouldLookForFirstVisibleColumn) {
+                while (rect.bottom >= frameDimensions.height) {
+                    if (isRectVisible(rect, false, frameDimensions)) {
+                        break;
+                    }
+                    offsetRectangle(rect, columnFullWidth, -frameDimensions.height);
                 }
             }
-
-            // Failed
-            else if (DEBUG) {
-                console.log('ieTextRangeWorkaround didn\'t work :(');
-            }
         }
 
-        if (DEBUG)
-        console.log('getVisibleTextRangeOffsetsSelectedByFunc: ', 'a0');
-        
-        // Desperately try to find it from all angles! Darn sub pixeling..
-        //TODO: remove the need for this brute-force method, since it's making the result non-deterministic
-        if (!caretRange || caretRange.startContainer !== textNode) {
-            caretRange = getCaretRangeFromPoint(fragmentCorner.x - 1, fragmentCorner.y);
-            
-            if (DEBUG)
-            console.log('getVisibleTextRangeOffsetsSelectedByFunc: ', 'a1');
-        }
-        if (!caretRange || caretRange.startContainer !== textNode) {
-            caretRange = getCaretRangeFromPoint(fragmentCorner.x, fragmentCorner.y - 1);
-            
-            if (DEBUG)
-            console.log('getVisibleTextRangeOffsetsSelectedByFunc: ', 'a2');
-        }
-        if (!caretRange || caretRange.startContainer !== textNode) {
-            caretRange = getCaretRangeFromPoint(fragmentCorner.x - 1, fragmentCorner.y - 1);
-            
-            if (DEBUG)
-            console.log('getVisibleTextRangeOffsetsSelectedByFunc: ', 'a3');
-        }
-        if (!caretRange || caretRange.startContainer !== textNode) {
-            fragmentCorner.x = Math.floor(fragmentCorner.x);
-            fragmentCorner.y = Math.floor(fragmentCorner.y);
-            caretRange = getCaretRangeFromPoint(fragmentCorner.x, fragmentCorner.y);
-            
-            if (DEBUG)
-            console.log('getVisibleTextRangeOffsetsSelectedByFunc: ', 'b0');
-        }
-        // Desperately try to find it from all angles! Darn sub pixeling..
-        if (!caretRange || caretRange.startContainer !== textNode) {
-            caretRange = getCaretRangeFromPoint(fragmentCorner.x - 1, fragmentCorner.y);
-            
-            if (DEBUG)
-            console.log('getVisibleTextRangeOffsetsSelectedByFunc: ', 'b1');
-        }
-        if (!caretRange || caretRange.startContainer !== textNode) {
-            caretRange = getCaretRangeFromPoint(fragmentCorner.x, fragmentCorner.y - 1);
-            
-            if (DEBUG)
-            console.log('getVisibleTextRangeOffsetsSelectedByFunc: ', 'b2');
-        }
-        if (!caretRange || caretRange.startContainer !== textNode) {
-            caretRange = getCaretRangeFromPoint(fragmentCorner.x - 1, fragmentCorner.y - 1);
-            
-            if (DEBUG)
-            console.log('getVisibleTextRangeOffsetsSelectedByFunc: ', 'b3');
-        }
-
-        // Still nothing? fall through..
-        if (!caretRange) {
-            
-            if (DEBUG)
-            console.warn('getVisibleTextRangeOffsetsSelectedByFunc: no caret range result');
-            
-            return null;
-        }
-
-        if (caretRange.startContainer === textNode) {
-            return pickerFunc(
-                [{start: caretRange.startOffset, end: caretRange.startOffset + 1},
-                {start: caretRange.startOffset - 1, end: caretRange.startOffset}]
-            );
-        } else {
-            
-            if (DEBUG)
-            console.warn('getVisibleTextRangeOffsetsSelectedByFunc: incorrect caret range result');
-            
-            return null;
-        }
-    }
-
-    function findVisibleLeafNodeCfi(leafNodeList, pickerFunc, targetLeafNode, visibleContentOffsets, frameDimensions, startingParent) {
-        var index = 0;
-        if (!targetLeafNode) {
-            index = leafNodeList.indexOf(pickerFunc(leafNodeList));
-            var leafNode = leafNodeList[index];
-            if (leafNode) {
-                startingParent = leafNode.element;
-            }
-        } else {
-            index = leafNodeList.indexOf(targetLeafNode);
-            if (index === -1) {
-                //target leaf node not the right type? not in list?
-                return null;
-            }
-            // use the next leaf node in the list
-            index += pickerFunc([1, -1]);
-        }
-        var visibleLeafNode = leafNodeList[index];
-
-        if (!visibleLeafNode) {
-            return null;
-        }
-
-        var element = visibleLeafNode.element;
-        var textNode = visibleLeafNode.textNode;
-
-        if (targetLeafNode && element !== startingParent && !_.contains($(textNode || element).parents(), startingParent)) {
-            if (DEBUG) console.warn("findVisibleLeafNodeCfi: stopped recursion early");
-            return null;
-        }
-
-        //if a valid text node is found, try to generate a CFI with range offsets
-        if (textNode && isValidTextNode(textNode)) {
-            var visibleRange = getVisibleTextRangeOffsetsSelectedByFunc(textNode, pickerFunc, visibleContentOffsets, frameDimensions);
-            if (!visibleRange) {
-                //the text node is valid, but not visible..
-                //let's try again with the next node in the list
-                return findVisibleLeafNodeCfi(leafNodeList, pickerFunc, visibleLeafNode, visibleContentOffsets, frameDimensions, startingParent);
-            }
-            var range = createRange();
-            range.setStart(textNode, visibleRange.start);
-            range.setEnd(textNode, visibleRange.end);
-            return generateCfiFromDomRange(range);
-        } else {
-            //if not then generate a CFI for the element
-            return self.getCfiForElement(element);
-        }
-    }
-
-    // get an array of visible text elements and then select one based on the func supplied
-    // and generate a CFI for the first visible text subrange.
-    function getVisibleTextRangeCfiForTextElementSelectedByFunc(pickerFunc, visibleContentOffsets, frameDimensions) {        
-        var visibleLeafNodeList = self.getVisibleLeafNodes(visibleContentOffsets, frameDimensions);
-        return findVisibleLeafNodeCfi(visibleLeafNodeList, pickerFunc, null, visibleContentOffsets, frameDimensions);
-    }
-
-    function getLastVisibleTextRangeCfi(visibleContentOffsets, frameDimensions) {
-        return getVisibleTextRangeCfiForTextElementSelectedByFunc(_.last, visibleContentOffsets, frameDimensions);
-    }
-
-    function getFirstVisibleTextRangeCfi(visibleContentOffsets, frameDimensions) {
-        return getVisibleTextRangeCfiForTextElementSelectedByFunc(_.first, visibleContentOffsets, frameDimensions);
-    }
-
-    this.getFirstVisibleCfi = function (visibleContentOffsets, frameDimensions) {
-        return getFirstVisibleTextRangeCfi(visibleContentOffsets, frameDimensions);
-    };
-
-    this.getLastVisibleCfi = function (visibleContentOffsets, frameDimensions) {
-        return getLastVisibleTextRangeCfi(visibleContentOffsets, frameDimensions);
-    };
-
-    function generateCfiFromDomRange(range) {
-        return EPUBcfi.generateRangeComponent(
-            range.startContainer, range.startOffset,
-            range.endContainer, range.endOffset,
-            self.getClassBlacklist(), self.getElementBlacklist(), self.getIdBlacklist());
-    }
-
-    function getRangeTargetNodes(rangeCfi) {
-        return EPUBcfi.getRangeTargetElements(
-            getWrappedCfi(rangeCfi),
-            self.getRootDocument(),
-            self.getClassBlacklist(), self.getElementBlacklist(), self.getIdBlacklist());
-    }
-
-    this.getDomRangeFromRangeCfi = function(rangeCfi, rangeCfi2, inclusive) {
-        var range = createRange();
-
-        if (!rangeCfi2) {
-            if (self.isRangeCfi(rangeCfi)) {
-                var rangeInfo = getRangeTargetNodes(rangeCfi);
-                range.setStart(rangeInfo.startElement, rangeInfo.startOffset);
-                range.setEnd(rangeInfo.endElement, rangeInfo.endOffset);
-            } else {
-                var element = self.getElementByCfi(rangeCfi,
-                    this.getClassBlacklist(), this.getElementBlacklist(), this.getIdBlacklist())[0];
-                range.selectNode(element);
-            }
-        } else {
-            if (self.isRangeCfi(rangeCfi)) {
-                var rangeInfo1 = getRangeTargetNodes(rangeCfi);
-                range.setStart(rangeInfo1.startElement, rangeInfo1.startOffset);
-            } else {
-                var startElement = self.getElementByCfi(rangeCfi,
-                    this.getClassBlacklist(), this.getElementBlacklist(), this.getIdBlacklist())[0];
-                range.setStart(startElement, 0);
-            }
-
-            if (self.isRangeCfi(rangeCfi2)) {
-                var rangeInfo2 = getRangeTargetNodes(rangeCfi2);
-                if (inclusive) {
-                    range.setEnd(rangeInfo2.endElement, rangeInfo2.endOffset);
-                } else {
-                    range.setEnd(rangeInfo2.startElement, rangeInfo2.startOffset);
-                }
-            } else {
-                var endElement = self.getElementByCfi(rangeCfi2,
-                    this.getClassBlacklist(), this.getElementBlacklist(), this.getIdBlacklist())[0];
-                range.setEnd(endElement, endElement.childNodes.length);
-            }
-        }
-        return range;
-    };
-
-    this.getRangeCfiFromDomRange = function(domRange) {
-        return generateCfiFromDomRange(domRange);
-    };
-
-    function getWrappedCfi(partialCfi) {
-        return "epubcfi(/99!" + partialCfi + ")";
-    }
-
-    this.isRangeCfi = function (partialCfi) {
-        return EPUBcfi.Interpreter.isRangeCfi(getWrappedCfi(partialCfi));
-    };
-
-    this.getPageIndexForCfi = function (partialCfi, classBlacklist, elementBlacklist, idBlacklist) {
-
-        if (this.isRangeCfi(partialCfi)) {
-            //if given a range cfi the exact page index needs to be calculated by getting node info from the range cfi
-            var nodeRangeInfoFromCfi = this.getNodeRangeInfoFromCfi(partialCfi);
-            //the page index is calculated from the node's client rectangle
-            return findPageBySingleRectangle(nodeRangeInfoFromCfi.clientRect);
-        }
-
-        var $element = getElementByPartialCfi(partialCfi, classBlacklist, elementBlacklist, idBlacklist);
-
-        if (!$element) {
-            return -1;
-        }
-
-        return this.getPageIndexForElement($element);
-    };
-
-    function getElementByPartialCfi(cfi, classBlacklist, elementBlacklist, idBlacklist) {
-
-        var contentDoc = self.getRootDocument();
-
-        var wrappedCfi = getWrappedCfi(cfi);
-
-        try {
-            //noinspection JSUnresolvedVariable
-            var $element = EPUBcfi.getTargetElement(wrappedCfi, contentDoc, classBlacklist, elementBlacklist, idBlacklist);
-
-        } catch (ex) {
-            //EPUBcfi.Interpreter can throw a SyntaxError
-        }
-
-        if (!$element || $element.length == 0) {
-            console.log("Can't find element for CFI: " + cfi);
-            return undefined;
-        }
-
-        return $element;
-    }
-
-    this.getElementFromPoint = function (x, y) {
-
-        var document = self.getRootDocument();
-        return document.elementFromPoint(x, y);
-    };
-
-    this.getNodeRangeInfoFromCfi = function (cfi) {
-        var contentDoc = self.getRootDocument();
-        if (self.isRangeCfi(cfi)) {
-            var wrappedCfi = getWrappedCfi(cfi);
-
-            try {
-                //noinspection JSUnresolvedVariable
-                var nodeResult = EPUBcfi.Interpreter.getRangeTargetElements(wrappedCfi, contentDoc,
-                    this.getClassBlacklist(),
-                    this.getElementBlacklist(),
-                    this.getIdBlacklist());
-
-                if (debugMode) {
-                    console.log(nodeResult);
-                }
-            } catch (ex) {
-                //EPUBcfi.Interpreter can throw a SyntaxError
-            }
-
-            if (!nodeResult) {
-                console.log("Can't find nodes for range CFI: " + cfi);
-                return undefined;
-            }
-
-            var startRangeInfo = {node: nodeResult.startElement, offset: nodeResult.startOffset};
-            var endRangeInfo = {node: nodeResult.endElement, offset: nodeResult.endOffset};
-            var nodeRangeClientRect =
-                startRangeInfo && endRangeInfo ?
-                    getNodeRangeClientRect(
-                        startRangeInfo.node,
-                        startRangeInfo.offset,
-                        endRangeInfo.node,
-                        endRangeInfo.offset)
-                    : null;
-
-            if (debugMode) {
-                console.log(nodeRangeClientRect);
-                addOverlayRect(nodeRangeClientRect, 'purple', contentDoc);
-            }
-
-            return {startInfo: startRangeInfo, endInfo: endRangeInfo, clientRect: nodeRangeClientRect}
-        } else {
-            var $element = self.getElementByCfi(cfi,
+        this.getCfiForElement = function (element) {
+            var cfi = EPUBcfi.Generator.generateElementCFIComponent(element,
                 this.getClassBlacklist(),
                 this.getElementBlacklist(),
                 this.getIdBlacklist());
 
-            var visibleContentOffsets = getVisibleContentOffsets();
-            return {startInfo: null, endInfo: null, clientRect: getNormalizedBoundingRect($element, visibleContentOffsets)};
+            if (cfi[0] == "!") {
+                cfi = cfi.substring(1);
+            }
+            return cfi;
+        };
+
+        this.getVisibleCfiFromPoint = function (x, y, precisePoint) {
+            var document = self.getRootDocument();
+            var firstVisibleCaretRange = getCaretRangeFromPoint(x, y, document);
+            var elementFromPoint = document.elementFromPoint(x, y);
+            var invalidElementFromPoint = !elementFromPoint || elementFromPoint === document.documentElement;
+
+            if (precisePoint) {
+                if (!elementFromPoint || invalidElementFromPoint) {
+                    return null;
+                }
+                var testRect = getNodeContentsClientRect(elementFromPoint);
+                if (!isRectVisible(testRect, false)) {
+                    return null;
+                }
+                if ((x < testRect.left || x > testRect.right) || (y < testRect.top || y > testRect.bottom)) {
+                    return null;
+                }
+            }
+
+            if (!firstVisibleCaretRange) {
+                if (invalidElementFromPoint) {
+                    console.error("Could not generate CFI no visible element on page");
+                    return null;
+                }
+                firstVisibleCaretRange = createRange();
+                firstVisibleCaretRange.selectNode(elementFromPoint);
+            }
+
+            var range = firstVisibleCaretRange;
+            var cfi;
+            //if we get a text node we need to get an approximate range for the first visible character offsets.
+            var node = range.startContainer;
+            var startOffset, endOffset;
+            if (node.nodeType === Node.TEXT_NODE) {
+                if (precisePoint && node.parentNode !== elementFromPoint) {
+                    return null;
+                }
+                if (node.length === 1 && range.startOffset === 1) {
+                    startOffset = 0;
+                    endOffset = 1;
+                } else if (range.startOffset === node.length) {
+                    startOffset = range.startOffset - 1;
+                    endOffset = range.startOffset;
+                } else {
+                    startOffset = range.startOffset;
+                    endOffset = range.startOffset + 1;
+                }
+                var wrappedRange = {
+                    startContainer: node,
+                    endContainer: node,
+                    startOffset: startOffset,
+                    endOffset: endOffset,
+                    commonAncestorContainer: range.commonAncestorContainer
+                };
+
+                if (debugMode) {
+                    drawDebugOverlayFromDomRange(wrappedRange);
+                }
+
+                cfi = generateCfiFromDomRange(wrappedRange);
+            } else if (node.nodeType === Node.ELEMENT_NODE) {
+                node =
+                    range.startContainer.childNodes[range.startOffset] ||
+                    range.startContainer.childNodes[0] ||
+                    range.startContainer;
+                if (precisePoint && node !== elementFromPoint) {
+                    return null;
+                }
+
+                if (node.nodeType !== Node.ELEMENT_NODE) {
+                    cfi = generateCfiFromDomRange(range);
+                } else {
+                    cfi = self.getCfiForElement(node);
+                }
+            } else {
+                if (precisePoint && node !== elementFromPoint) {
+                    return null;
+                }
+
+                cfi = self.getCfiForElement(elementFromPoint);
+            }
+
+            //This should not happen but if it does print some output, just in case
+            if (cfi && cfi.indexOf('NaN') !== -1) {
+                console.log('Did not generate a valid CFI:' + cfi);
+                return undefined;
+            }
+
+            return cfi;
+        };
+
+        this.getRangeCfiFromPoints = function (startX, startY, endX, endY) {
+            var document = self.getRootDocument();
+            var start = getCaretRangeFromPoint(startX, startY, document),
+                end = getCaretRangeFromPoint(endX, endY, document),
+                range = createRange();
+            range.setStart(start.startContainer, start.startOffset);
+            range.setEnd(end.startContainer, end.startOffset);
+            // if we're looking at a text node create a nice range (n, n+1)
+            if (start.startContainer === start.endContainer && start.startContainer.nodeType === Node.TEXT_NODE && end.startContainer.length > end.startOffset + 1) {
+                range.setEnd(end.startContainer, end.startOffset + 1);
+            }
+            return generateCfiFromDomRange(range);
+        };
+
+        function getTextNodeRectCornerPairs(rect) {
+            //
+            //    top left             top right
+            //    ╲                   ╱
+            //  ── ▒T▒E▒X▒T▒ ▒R▒E▒C▒T▒ ──
+            //
+            // top left corner & top right corner
+            // but for y coord use the mid point between top and bottom
+
+            if (isVerticalWritingMode()) {
+                var x = rect.right - (rect.width / 2);
+                return [{x: x, y: rect.top}, {x: x, y: rect.bottom}];
+            } else {
+                var y = rect.top + (rect.height / 2);
+                var result = [{x: rect.left, y: y}, {x: rect.right, y: y}];
+                return isPageProgressionRightToLeft() ? result.reverse() : result;
+            }
         }
-    };
 
-    this.isNodeFromRangeCfiVisible = function (cfi) {
-        var nodeRangeInfo = this.getNodeRangeInfoFromCfi(cfi);
-        if (nodeRangeInfo) {
-            return isRectVisible(nodeRangeInfo.clientRect, false);
-        } else {
-            return undefined;
+        var DEBUG = false;
+
+
+
+        function determineSplit (Range,division) {
+            //either  50/50 or 60 /40
+           var percent = parseFloat(division)/parseFloat(100);
+           var length =  Math.floor((Range.endOffset - Range.startOffset) * percent);
+           return length;
+
         }
-    };
+        function splitRange(Range, division) {
+            var length = determineSplit(Range,parseFloat(division));
+            if (length <= 0 ){
+                return [Range];
+            }
+            var textNode = Range.startContainer;
+            var leftNodeRange = Range.cloneRange();
+            leftNodeRange.setStart(textNode, Range.startOffset);
+            leftNodeRange.setEnd(textNode, Range.startOffset + length);
+            var rightNodeRange = Range.cloneRange();
+            rightNodeRange.setStart(textNode, Range.startOffset + length);
+            rightNodeRange.setEnd(textNode, Range.endOffset);
 
-    this.getElementByCfi = function (partialCfi, classBlacklist, elementBlacklist, idBlacklist) {
-        return getElementByPartialCfi(partialCfi, classBlacklist, elementBlacklist, idBlacklist);
-    };
+            return [leftNodeRange, rightNodeRange];
 
-    this.getPageIndexForElement = function ($element) {
-
-        var pageIndex = findPageByRectangles($element);
-        if (pageIndex === null) {
-            console.warn('Impossible to locate a hidden element: ', $element);
-            return 0;
-        }
-        return pageIndex;
-    };
-
-    this.getElementById = function (id) {
-
-        var contentDoc = this.getRootDocument();
-
-        var $element = $(contentDoc.getElementById(id));
-        //$("#" + Helpers.escapeJQuerySelector(id), contentDoc);
-
-        if($element.length == 0) {
-            return undefined;
         }
 
-        return $element;
-    };
+        // create Range from target node and search for visibleOutput Range
+        function getVisibleTextRangeOffsets(textNode, pickerFunc, visibleContentOffsets, frameDimensions) {
+            visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
 
-    this.getPageIndexForElementId = function (id) {
+            // Create a Range around targeted textNode
+            var nodeRange = createRangeFromNode(textNode);
+            // split the range into two halves
 
-        var $element = this.getElementById(id);
-        if (!$element) {
-            return -1;
+            //Split Ratio depends whether we are searching for the lastCFI or first CFI, last CFI will most likely be near the end of the given view , so we allocate the spliting to be 60/40
+            // 40/60 for firstCFI
+
+            var outputRange = getTextRangeOffset(splitRange(nodeRange, parseFloat(50)), visibleContentOffsets, pickerFunc([0, 1]),
+                function (rect) {
+                    return (isVerticalWritingMode() ? rect.height : rect.width) && isRectVisible(rect, false, frameDimensions);
+                });
+            return outputRange;
+            // Split Range into two halves for binary search implementation
+
         }
 
-        return this.getPageIndexForElement($element);
-    };
 
-    // returns raw DOM element (not $ jQuery-wrapped)
-    this.getFirstVisibleMediaOverlayElement = function(visibleContentOffsets) {
-        var $root = $(this.getBodyElement());
-        if (!$root || !$root.length || !$root[0]) return undefined;
+        // reverses a directionBit
+        function changeDirection (directionBit) {
+            if (directionBit == 1 ) {return 0;}
+            else { return 1;}
 
-        var that = this;
+        }
 
-        var firstPartial = undefined;
+        function getTextRangeOffset(startingSet, visibleContentOffsets, directionBit, filterfunc) {
 
-        function traverseArray(arr) {
-            if (!arr || !arr.length) return undefined;
+            var currRange = startingSet;
+            var count = 1 ;
 
-            for (var i = 0, count = arr.length; i < count; i++) {
-                var item = arr[i];
-                if (!item) continue;
+            //begin iterative binary search, each iteration will check Range length and visibility
+            // if current range has visible fragments we check the range length
+            // if not visible check the other half.
+            while (currRange.length !=1) {
+                count ++;
+                if(currRange.length <= 1) { return currRange;}
+                var currTextNodeFragments = getRangeClientRectList(currRange[directionBit], visibleContentOffsets);
+                if (fragmentVisible(currTextNodeFragments, filterfunc)) {
+                    currRange = splitRange(currRange[directionBit], parseFloat(50));
+                }
+                    // No visible fragment Look in other half
+                 else {
+                    currRange = splitRange(currRange[changeDirection(directionBit)], parseFloat(50));
+                 }
+            }
+            console.log(count);
+            return currRange[0];
+        }
 
-                var $item = $(item);
+        function fragmentVisible(fragments,filterfunc) {
+            var visibleFragments = _.filter(fragments,filterfunc);
+            var testBool = visibleFragments.length? true: false;
+            return visibleFragments.length ? true : false;
+        }
 
-                if ($item.data("mediaOverlayData")) {
-                    var visible = that.getElementVisibility($item, visibleContentOffsets);
-                    if (visible) {
-                        if (!firstPartial) firstPartial = item;
+        function findVisibleLeafNodeCfi(leafNodeList, pickerFunc, targetLeafNode, visibleContentOffsets, frameDimensions, startingParent) {
+            var index = 0;
 
-                        if (visible == 100) return item;
+            if (!targetLeafNode) {
+                index = leafNodeList.indexOf(pickerFunc(leafNodeList));
+                var leafNode = leafNodeList[index];
+                if (leafNode) {
+                    startingParent = leafNode.element;
+                }
+            } else {
+                index = leafNodeList.indexOf(targetLeafNode);
+                if (index === -1) {
+                    //target leaf node not the right type? not in list?
+                    return null;
+                }
+                // use the next leaf node in the list
+                index += pickerFunc([1, -1]);
+            }
+            var visibleLeafNode = leafNodeList[index];
+
+            if (!visibleLeafNode) {
+                return null;
+            }
+
+            var element = visibleLeafNode.element;
+            var textNode = visibleLeafNode.textNode;
+
+            if (targetLeafNode && element !== startingParent && !_.contains($(textNode || element).parents(), startingParent)) {
+                if (DEBUG) console.warn("findVisibleLeafNodeCfi: stopped recursion early");
+                return null;
+            }
+
+            //if a valid text node is found, try to generate a CFI with range offsets
+            if (textNode && isValidTextNode(textNode)) {
+
+                var visibleRange = getVisibleTextRangeOffsets(textNode, pickerFunc, visibleContentOffsets, frameDimensions);
+                if (!visibleRange) {
+                    //the text node is valid, but not visible..
+                    //let's try again with the next node in the list
+                    return findVisibleLeafNodeCfi(leafNodeList, pickerFunc, visibleLeafNode, visibleContentOffsets, frameDimensions, startingParent);
+                }
+                return generateCfiFromDomRange(visibleRange);
+            } else {
+                //if not then generate a CFI for the element
+                return self.getCfiForElement(element);
+            }
+        }
+
+        // get an array of visible text elements and then select one based on the func supplied
+        // and generate a CFI for the first visible text subrange.
+        function getVisibleTextRangeCfiForTextElementSelectedByFunc(pickerFunc, visibleContentOffsets, frameDimensions) {
+            var visibleLeafNodeList = self.getVisibleLeafNodes(visibleContentOffsets, frameDimensions);
+            return findVisibleLeafNodeCfi(visibleLeafNodeList, pickerFunc, null, visibleContentOffsets, frameDimensions);
+        }
+
+        function getLastVisibleTextRangeCfi(visibleContentOffsets, frameDimensions) {
+            return getVisibleTextRangeCfiForTextElementSelectedByFunc(_.last, visibleContentOffsets, frameDimensions);
+        }
+
+        function getFirstVisibleTextRangeCfi(visibleContentOffsets, frameDimensions) {
+            return getVisibleTextRangeCfiForTextElementSelectedByFunc(_.first, visibleContentOffsets, frameDimensions);
+        }
+
+        this.getFirstVisibleCfi = function (visibleContentOffsets, frameDimensions) {
+            return getFirstVisibleTextRangeCfi(visibleContentOffsets, frameDimensions);
+        };
+
+        this.getLastVisibleCfi = function (visibleContentOffsets, frameDimensions) {
+            return getLastVisibleTextRangeCfi(visibleContentOffsets, frameDimensions);
+        };
+
+        function generateCfiFromDomRange(range) {
+            return EPUBcfi.generateRangeComponent(
+                range.startContainer, range.startOffset,
+                range.endContainer, range.endOffset,
+                self.getClassBlacklist(), self.getElementBlacklist(), self.getIdBlacklist());
+        }
+
+        function getRangeTargetNodes(rangeCfi) {
+            return EPUBcfi.getRangeTargetElements(
+                getWrappedCfi(rangeCfi),
+                self.getRootDocument(),
+                self.getClassBlacklist(), self.getElementBlacklist(), self.getIdBlacklist());
+        }
+
+        this.getDomRangeFromRangeCfi = function (rangeCfi, rangeCfi2, inclusive) {
+            var range = createRange();
+
+            if (!rangeCfi2) {
+                if (self.isRangeCfi(rangeCfi)) {
+                    var rangeInfo = getRangeTargetNodes(rangeCfi);
+                    range.setStart(rangeInfo.startElement, rangeInfo.startOffset);
+                    range.setEnd(rangeInfo.endElement, rangeInfo.endOffset);
+                } else {
+                    var element = self.getElementByCfi(rangeCfi,
+                        this.getClassBlacklist(), this.getElementBlacklist(), this.getIdBlacklist())[0];
+                    range.selectNode(element);
+                }
+            } else {
+                if (self.isRangeCfi(rangeCfi)) {
+                    var rangeInfo1 = getRangeTargetNodes(rangeCfi);
+                    range.setStart(rangeInfo1.startElement, rangeInfo1.startOffset);
+                } else {
+                    var startElement = self.getElementByCfi(rangeCfi,
+                        this.getClassBlacklist(), this.getElementBlacklist(), this.getIdBlacklist())[0];
+                    range.setStart(startElement, 0);
+                }
+
+                if (self.isRangeCfi(rangeCfi2)) {
+                    var rangeInfo2 = getRangeTargetNodes(rangeCfi2);
+                    if (inclusive) {
+                        range.setEnd(rangeInfo2.endElement, rangeInfo2.endOffset);
+                    } else {
+                        range.setEnd(rangeInfo2.startElement, rangeInfo2.startOffset);
+                    }
+                } else {
+                    var endElement = self.getElementByCfi(rangeCfi2,
+                        this.getClassBlacklist(), this.getElementBlacklist(), this.getIdBlacklist())[0];
+                    range.setEnd(endElement, endElement.childNodes.length);
+                }
+            }
+            return range;
+        };
+
+        this.getRangeCfiFromDomRange = function (domRange) {
+            return generateCfiFromDomRange(domRange);
+        };
+
+        function getWrappedCfi(partialCfi) {
+            return "epubcfi(/99!" + partialCfi + ")";
+        }
+
+        this.isRangeCfi = function (partialCfi) {
+            return EPUBcfi.Interpreter.isRangeCfi(getWrappedCfi(partialCfi));
+        };
+
+        this.getPageIndexForCfi = function (partialCfi, classBlacklist, elementBlacklist, idBlacklist) {
+
+            if (this.isRangeCfi(partialCfi)) {
+                //if given a range cfi the exact page index needs to be calculated by getting node info from the range cfi
+                var nodeRangeInfoFromCfi = this.getNodeRangeInfoFromCfi(partialCfi);
+                //the page index is calculated from the node's client rectangle
+                return findPageBySingleRectangle(nodeRangeInfoFromCfi.clientRect);
+            }
+
+            var $element = getElementByPartialCfi(partialCfi, classBlacklist, elementBlacklist, idBlacklist);
+
+            if (!$element) {
+                return -1;
+            }
+
+            return this.getPageIndexForElement($element);
+        };
+
+        function getElementByPartialCfi(cfi, classBlacklist, elementBlacklist, idBlacklist) {
+
+            var contentDoc = self.getRootDocument();
+
+            var wrappedCfi = getWrappedCfi(cfi);
+
+            try {
+                //noinspection JSUnresolvedVariable
+                var $element = EPUBcfi.getTargetElement(wrappedCfi, contentDoc, classBlacklist, elementBlacklist, idBlacklist);
+
+            } catch (ex) {
+                //EPUBcfi.Interpreter can throw a SyntaxError
+            }
+
+            if (!$element || $element.length == 0) {
+                console.log("Can't find element for CFI: " + cfi);
+                return undefined;
+            }
+
+            return $element;
+        }
+
+        this.getElementFromPoint = function (x, y) {
+
+            var document = self.getRootDocument();
+            return document.elementFromPoint(x, y);
+        };
+
+        this.getNodeRangeInfoFromCfi = function (cfi) {
+            var contentDoc = self.getRootDocument();
+            if (self.isRangeCfi(cfi)) {
+                var wrappedCfi = getWrappedCfi(cfi);
+
+                try {
+                    //noinspection JSUnresolvedVariable
+                    var nodeResult = EPUBcfi.Interpreter.getRangeTargetElements(wrappedCfi, contentDoc,
+                        this.getClassBlacklist(),
+                        this.getElementBlacklist(),
+                        this.getIdBlacklist());
+
+                    if (debugMode) {
+                        console.log(nodeResult);
+                    }
+                } catch (ex) {
+                    //EPUBcfi.Interpreter can throw a SyntaxError
+                }
+
+                if (!nodeResult) {
+                    console.log("Can't find nodes for range CFI: " + cfi);
+                    return undefined;
+                }
+
+                var startRangeInfo = {node: nodeResult.startElement, offset: nodeResult.startOffset};
+                var endRangeInfo = {node: nodeResult.endElement, offset: nodeResult.endOffset};
+                var nodeRangeClientRect =
+                    startRangeInfo && endRangeInfo ?
+                        getNodeRangeClientRect(
+                            startRangeInfo.node,
+                            startRangeInfo.offset,
+                            endRangeInfo.node,
+                            endRangeInfo.offset)
+                        : null;
+
+                if (debugMode) {
+                    console.log(nodeRangeClientRect);
+                    addOverlayRect(nodeRangeClientRect, 'purple', contentDoc);
+                }
+
+                return {startInfo: startRangeInfo, endInfo: endRangeInfo, clientRect: nodeRangeClientRect}
+            } else {
+                var $element = self.getElementByCfi(cfi,
+                    this.getClassBlacklist(),
+                    this.getElementBlacklist(),
+                    this.getIdBlacklist());
+
+                var visibleContentOffsets = getVisibleContentOffsets();
+                return {
+                    startInfo: null,
+                    endInfo: null,
+                    clientRect: getNormalizedBoundingRect($element, visibleContentOffsets)
+                };
+            }
+        };
+
+        this.isNodeFromRangeCfiVisible = function (cfi) {
+            var nodeRangeInfo = this.getNodeRangeInfoFromCfi(cfi);
+            if (nodeRangeInfo) {
+                return isRectVisible(nodeRangeInfo.clientRect, false);
+            } else {
+                return undefined;
+            }
+        };
+
+        this.getElementByCfi = function (partialCfi, classBlacklist, elementBlacklist, idBlacklist) {
+            return getElementByPartialCfi(partialCfi, classBlacklist, elementBlacklist, idBlacklist);
+        };
+
+        this.getPageIndexForElement = function ($element) {
+
+            var pageIndex = findPageByRectangles($element);
+            if (pageIndex === null) {
+                console.warn('Impossible to locate a hidden element: ', $element);
+                return 0;
+            }
+            return pageIndex;
+        };
+
+        this.getElementById = function (id) {
+
+            var contentDoc = this.getRootDocument();
+
+            var $element = $(contentDoc.getElementById(id));
+            //$("#" + Helpers.escapeJQuerySelector(id), contentDoc);
+
+            if ($element.length == 0) {
+                return undefined;
+            }
+
+            return $element;
+        };
+
+        this.getPageIndexForElementId = function (id) {
+
+            var $element = this.getElementById(id);
+            if (!$element) {
+                return -1;
+            }
+
+            return this.getPageIndexForElement($element);
+        };
+
+        // returns raw DOM element (not $ jQuery-wrapped)
+        this.getFirstVisibleMediaOverlayElement = function (visibleContentOffsets) {
+            var $root = $(this.getBodyElement());
+            if (!$root || !$root.length || !$root[0]) return undefined;
+
+            var that = this;
+
+            var firstPartial = undefined;
+
+            function traverseArray(arr) {
+                if (!arr || !arr.length) return undefined;
+
+                for (var i = 0, count = arr.length; i < count; i++) {
+                    var item = arr[i];
+                    if (!item) continue;
+
+                    var $item = $(item);
+
+                    if ($item.data("mediaOverlayData")) {
+                        var visible = that.getElementVisibility($item, visibleContentOffsets);
+                        if (visible) {
+                            if (!firstPartial) firstPartial = item;
+
+                            if (visible == 100) return item;
+                        }
+                    }
+                    else {
+                        var elem = traverseArray(item.children);
+                        if (elem) return elem;
                     }
                 }
-                else {
-                    var elem = traverseArray(item.children);
-                    if (elem) return elem;
+
+                return undefined;
+            }
+
+            var el = traverseArray([$root[0]]);
+            if (!el) el = firstPartial;
+            return el;
+
+            // var $elements = this.getMediaOverlayElements($root);
+            // return this.getVisibleElements($elements, visibleContentOffsets);
+        };
+
+        this.getElementVisibility = function ($element, visibleContentOffsets) {
+            return checkVisibilityByRectangles($element, true, visibleContentOffsets);
+        };
+
+
+        this.isElementVisible = this.getElementVisibility;
+
+        this.getVisibleElementsWithFilter = function (visibleContentOffsets, filterFunction) {
+            var $elements = this.getElementsWithFilter($(this.getBodyElement()), filterFunction);
+            return this.getVisibleElements($elements, visibleContentOffsets);
+        };
+
+        this.getAllElementsWithFilter = function (filterFunction) {
+            return this.getElementsWithFilter($(this.getBodyElement()), filterFunction);
+        };
+
+        this.getAllVisibleElementsWithSelector = function (selector, visibleContentOffset) {
+            var elements = $(selector, this.getRootElement());
+            var $newElements = [];
+            $.each(elements, function () {
+                $newElements.push($(this));
+            });
+            return this.getVisibleElements($newElements, visibleContentOffset);
+        };
+
+        this.getVisibleElements = function ($elements, visibleContentOffsets, frameDimensions) {
+
+            var visibleElements = [];
+
+            _.each($elements, function ($node) {
+                var isTextNode = ($node[0].nodeType === Node.TEXT_NODE);
+                var $element = isTextNode ? $node.parent() : $node;
+                var visibilityPercentage = checkVisibilityByRectangles(
+                    $node, true, visibleContentOffsets, frameDimensions);
+
+                if (visibilityPercentage) {
+                    visibleElements.push({
+                        element: $element[0], // DOM Element is pushed
+                        textNode: isTextNode ? $node[0] : null,
+                        percentVisible: visibilityPercentage
+                    });
+                }
+            });
+
+            return visibleElements;
+        };
+
+        this.getVisibleLeafNodes = function (visibleContentOffsets, frameDimensions) {
+
+            if (_cacheEnabled) {
+                var cacheKey = (options.paginationInfo || {}).currentSpreadIndex || 0;
+                var fromCache = _cache.visibleLeafNodes.get(cacheKey);
+                if (fromCache) {
+                    return fromCache;
                 }
             }
 
-            return undefined;
-        }
+            var $elements = this.getLeafNodeElements($(this.getBodyElement()));
 
-        var el = traverseArray([$root[0]]);
-        if (!el) el = firstPartial;
-        return el;
+            var visibleElements = this.getVisibleElements($elements, visibleContentOffsets, frameDimensions);
 
-        // var $elements = this.getMediaOverlayElements($root);
-        // return this.getVisibleElements($elements, visibleContentOffsets);
-    };
-
-    this.getElementVisibility = function ($element, visibleContentOffsets) {
-        return checkVisibilityByRectangles($element, true, visibleContentOffsets);
-    };
-
-
-    this.isElementVisible = checkVisibilityByRectangles;
-
-    this.getVisibleElementsWithFilter = function (visibleContentOffsets, filterFunction) {
-        var $elements = this.getElementsWithFilter($(this.getBodyElement()), filterFunction);
-        return this.getVisibleElements($elements, visibleContentOffsets);
-    };
-
-    this.getAllElementsWithFilter = function (filterFunction) {
-        return this.getElementsWithFilter($(this.getBodyElement()), filterFunction);
-    };
-
-    this.getAllVisibleElementsWithSelector = function (selector, visibleContentOffset) {
-        var elements = $(selector, this.getRootElement());
-        var $newElements = [];
-        $.each(elements, function () {
-            $newElements.push($(this));
-        });
-        return this.getVisibleElements($newElements, visibleContentOffset);
-    };
-
-    this.getVisibleElements = function ($elements, visibleContentOffsets, frameDimensions) {
-
-        var visibleElements = [];
-
-        _.each($elements, function ($node) {
-            var node = $node[0];
-            var isTextNode = (node.nodeType === Node.TEXT_NODE);
-            var element = isTextNode ? node.parentElement : node;
-            var visibilityPercentage = checkVisibilityByRectangles(
-                $node, true, visibleContentOffsets, frameDimensions);
-
-            if (visibilityPercentage) {
-                visibleElements.push({
-                    element: element, // DOM Element is pushed
-                    textNode: isTextNode ? node : null,
-                    percentVisible: visibilityPercentage
-                });
+            if (_cacheEnabled) {
+                _cache.visibleLeafNodes.set(cacheKey, visibleElements);
             }
-        });
 
-        return visibleElements;
-    };
+            return visibleElements;
+        };
 
-    this.getVisibleLeafNodes = function (visibleContentOffsets, frameDimensions) {
+        this.getElementsWithFilter = function ($root, filterFunction) {
 
-        if (_cacheEnabled) {
-            var cacheKey = (options.paginationInfo || {}).currentSpreadIndex || 0;
-            var fromCache = _cache.visibleLeafNodes.get(cacheKey);
-            if (fromCache) {
-                return fromCache;
-            }
-        }
+            var $elements = [];
 
-        var $elements = this.getLeafNodeElements($(this.getBodyElement()));
+            function traverseCollection(elements) {
 
-        var visibleElements = this.getVisibleElements($elements, visibleContentOffsets, frameDimensions);
+                if (elements == undefined) return;
 
-        if (_cacheEnabled) {
-            _cache.visibleLeafNodes.set(cacheKey, visibleElements);
-        }
+                for (var i = 0, count = elements.length; i < count; i++) {
 
-        return visibleElements;
-    };
+                    var $element = $(elements[i]);
 
-    this.getElementsWithFilter = function ($root, filterFunction) {
+                    if (filterFunction($element)) {
+                        $elements.push($element);
+                    }
+                    else {
+                        traverseCollection($element[0].children);
+                    }
 
-        var $elements = [];
-
-        function traverseCollection(elements) {
-
-            if (elements == undefined) return;
-
-            for (var i = 0, count = elements.length; i < count; i++) {
-
-                var $element = $(elements[i]);
-
-                if (filterFunction($element)) {
-                    $elements.push($element);
                 }
-                else {
-                    traverseCollection($element[0].children);
+            }
+
+            traverseCollection([$root[0]]);
+
+            return $elements;
+        };
+
+        function isElementBlacklisted(element) {
+            var isBlacklisted = false;
+            var classAttribute = element.className;
+            // check for SVGAnimatedString
+            if (classAttribute && typeof classAttribute.animVal !== "undefined") {
+                classAttribute = classAttribute.animVal;
+            } else if (classAttribute && typeof classAttribute.baseVal !== "undefined") {
+                classAttribute = classAttribute.baseVal;
+            }
+            var classList = classAttribute ? classAttribute.split(' ') : [];
+            var id = element.id;
+
+            var classBlacklist = self.getClassBlacklist();
+            if (classList.length === 1 && _.contains(classBlacklist, classList[0])) {
+                isBlacklisted = true;
+                return;
+            } else if (classList.length && _.intersection(classBlacklist, classList).length) {
+                isBlacklisted = true;
+                return;
+            }
+
+            if (id && id.length && _.contains(self.getIdBlacklist(), id)) {
+                isBlacklisted = true;
+                return;
+            }
+
+            return isBlacklisted;
+        }
+
+        this.getLeafNodeElements = function ($root) {
+
+            if (_cacheEnabled) {
+                var fromCache = _cache.leafNodeElements.get($root);
+                if (fromCache) {
+                    return fromCache;
                 }
-
             }
-        }
 
-        traverseCollection([$root[0]]);
+            //noinspection JSUnresolvedVariable,JSCheckFunctionSignatures
+            var nodeIterator = document.createNodeIterator(
+                $root[0],
+                NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
+                function () {
+                    //noinspection JSUnresolvedVariable
+                    return NodeFilter.FILTER_ACCEPT;
+                },
+                false
+            );
 
-        return $elements;
-    };
-
-    function isElementBlacklisted(element) {
-        var isBlacklisted = false;
-        var classAttribute = element.className;
-        // check for SVGAnimatedString
-        if (classAttribute && typeof classAttribute.animVal !== "undefined") {
-            classAttribute = classAttribute.animVal;
-        } else if (classAttribute && typeof classAttribute.baseVal !== "undefined") {
-            classAttribute = classAttribute.baseVal;
-        }
-        var classList = classAttribute ? classAttribute.split(' ') : [];
-        var id = element.id;
-
-        var classBlacklist = self.getClassBlacklist();
-        if (classList.length === 1 && _.contains(classBlacklist, classList[0])) {
-            isBlacklisted = true;
-            return;
-        } else if (classList.length && _.intersection(classBlacklist, classList).length) {
-            isBlacklisted = true;
-            return;
-        }
-
-        if (id && id.length && _.contains(self.getIdBlacklist(), id)) {
-            isBlacklisted = true;
-            return;
-        }
-
-        return isBlacklisted;
-    }
-
-    this.getLeafNodeElements = function ($root) {
-
-        if (_cacheEnabled) {
-            var fromCache = _cache.leafNodeElements.get($root);
-            if (fromCache) {
-                return fromCache;
-            }
-        }
-
-        //noinspection JSUnresolvedVariable,JSCheckFunctionSignatures
-        var nodeIterator = document.createNodeIterator(
-            $root[0],
-            NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
-            function() {
-                //noinspection JSUnresolvedVariable
-                return NodeFilter.FILTER_ACCEPT;
-            },
-            false
-        );
-
-        var $leafNodeElements = [];
+            var $leafNodeElements = [];
 
         var node;
         while ((node = nodeIterator.nextNode())) {
@@ -1339,83 +1292,82 @@ var CfiNavigationLogic = function(options) {
                     $leafNodeElements.push($(node));
                 }
             }
-        }
 
-        if (_cacheEnabled) {
-            _cache.leafNodeElements.set($root, $leafNodeElements);
-        }
+            if (_cacheEnabled) {
+                _cache.leafNodeElements.set($root, $leafNodeElements);
+            }
 
-        return $leafNodeElements;
-    };
-
-    function isValidTextNode(node) {
-
-        if (node.nodeType === Node.TEXT_NODE) {
-
-            return isValidTextNodeContent(node.nodeValue);
-        }
-
-        return false;
-
-    }
-
-    function isValidTextNodeContent(text) {
-        // Heuristic to find a text node with actual text
-        // If we don't do this, we may get a reference to a node that doesn't get rendered
-        // (such as for example a node that has tab character and a bunch of spaces)
-        // this is would be bad! ask me why.
-        return !!text.trim().length;
-    }
-
-    this.getElements = function (selector) {
-        if (!selector) {
-            return $(this.getRootElement()).children();
-        }
-        return $(selector, this.getRootElement());
-    };
-
-    this.getElement = function (selector) {
-
-        var $element = this.getElements(selector);
-
-        if($element.length > 0) {
-            return $element;
-        }
-
-        return undefined;
-    };
-
-    function Cache() {
-        var that = this;
-
-        //true = survives invalidation
-        var props = {
-            leafNodeElements: true,
-            visibleLeafNodes: false
+            return $leafNodeElements;
         };
 
-        _.each(props, function (val, key) {
-            that[key] = new Map();
-        });
+        function isValidTextNode(node) {
 
-        this._invalidate = function () {
-            _.each(props, function (val, key) {
-                if (!val) {
-                    that[key] = new Map();
-                }
-            });
+            if (node.nodeType === Node.TEXT_NODE) {
+
+                return isValidTextNodeContent(node.nodeValue);
+            }
+
+            return false;
+
         }
-    }
 
-    var _cache = new Cache();
+        function isValidTextNodeContent(text) {
+            // Heuristic to find a text node with actual text
+            // If we don't do this, we may get a reference to a node that doesn't get rendered
+            // (such as for example a node that has tab character and a bunch of spaces)
+            // this is would be bad! ask me why.
+            return !!text.trim().length;
+        }
 
-    var _cacheEnabled = false;
+        this.getElements = function (selector) {
+            if (!selector) {
+                return $(this.getRootElement()).children();
+            }
+            return $(selector, this.getRootElement());
+        };
 
-    this.invalidateCache = function () {
-        _cache._invalidate();
-    };
+        this.getElement = function (selector) {
 
-    //if (debugMode) {
+            var $element = this.getElements(selector);
+
+            if ($element.length > 0) {
+                return $element;
+            }
+
+            return undefined;
+        };
+
+        function Cache() {
+            var that = this;
+
+            //true = survives invalidation
+            var props = {
+                leafNodeElements: true,
+                visibleLeafNodes: false
+            };
+
+            _.each(props, function (val, key) {
+                that[key] = new Map();
+            });
+
+            this._invalidate = function () {
+                _.each(props, function (val, key) {
+                    if (!val) {
+                        that[key] = new Map();
+                    }
+                });
+            }
+        }
+
+        var _cache = new Cache();
+
+        var _cacheEnabled = false;
+
+        this.invalidateCache = function () {
+            _cache._invalidate();
+        };
+
+        //if (debugMode) {
 
         var $debugOverlays = [];
 
@@ -1492,7 +1444,7 @@ var CfiNavigationLogic = function(options) {
         }
 
         function clearDebugOverlays() {
-            _.each($debugOverlays, function($el){
+            _.each($debugOverlays, function ($el) {
                 $el.remove();
             });
             $debugOverlays = [];
@@ -1517,8 +1469,8 @@ var CfiNavigationLogic = function(options) {
         };
 
         //
-   // }
+        // }
 
-};
+    }
 return CfiNavigationLogic;
 });

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -330,13 +330,13 @@ var CfiNavigationLogic = function (options) {
         }
 
         /**
-         * Finds a page index (0-based) for a specific element.
+         * Finds a page index (0-based) delta for a specific element.
          * Calculations are based on rectangles retrieved with getClientRects() method.
          *
          * @param {jQuery} $element
          * @returns {number|null}
          */
-        function findPageByRectangles($element) {
+        function findPageIndexDeltaByRectangles($element) {
 
             var visibleContentOffsets = getVisibleContentOffsets();
 
@@ -345,19 +345,19 @@ var CfiNavigationLogic = function (options) {
                 return null;
             }
 
-            return calculatePageIndexByRectangles(clientRectangles);
+            return calculatePageIndexDeltaByRectangles(clientRectangles);
         }
 
         /**
          * @private
-         * Calculate a page index (0-based) for given client rectangles.
+         * Calculate a page index (0-based) delta for given client rectangles.
          *
          * @param {object[]} clientRectangles
          * @param {object} [frameDimensions]
          * @param {number} [columnFullWidth]
          * @returns {number|null}
          */
-        function calculatePageIndexByRectangles(clientRectangles, frameDimensions, columnFullWidth) {
+        function calculatePageIndexDeltaByRectangles(clientRectangles, frameDimensions, columnFullWidth) {
             var isRtl = isPageProgressionRightToLeft();
             var isVwm = isVerticalWritingMode();
             columnFullWidth = columnFullWidth || getColumnFullWidth();
@@ -385,7 +385,7 @@ var CfiNavigationLogic = function (options) {
         }
 
         /**
-         * Finds a page index (0-based) for a specific client rectangle.
+         * Finds a page index (0-based) delta for a specific client rectangle.
          * Calculations are based on viewport dimensions, offsets, and rectangle coordinates
          *
          * @param {ClientRect} clientRectangle
@@ -393,14 +393,14 @@ var CfiNavigationLogic = function (options) {
          * @param {Object} [frameDimensions]
          * @returns {number|null}
          */
-        function findPageBySingleRectangle(clientRectangle, visibleContentOffsets, frameDimensions) {
+        function findPageIndexDeltaBySingleRectangle(clientRectangle, visibleContentOffsets, frameDimensions) {
             visibleContentOffsets = visibleContentOffsets || getVisibleContentOffsets();
             frameDimensions = frameDimensions || getFrameDimensions();
 
             var normalizedRectangle = normalizeRectangle(
                 clientRectangle, visibleContentOffsets.left, visibleContentOffsets.top);
 
-            return calculatePageIndexByRectangles([normalizedRectangle], frameDimensions);
+            return calculatePageIndexDeltaByRectangles([normalizedRectangle], frameDimensions);
         }
 
         /**
@@ -971,13 +971,13 @@ var CfiNavigationLogic = function (options) {
             return EPUBcfi.Interpreter.hasTextTerminus(getWrappedCfi(partialCfi));
         }
 
-        this.getPageIndexForCfi = function (partialCfi, classBlacklist, elementBlacklist, idBlacklist) {
+        this.getPageIndexDeltaForCfi = function (partialCfi, classBlacklist, elementBlacklist, idBlacklist) {
 
             if (this.isRangeCfi(partialCfi)) {
                 //if given a range cfi the exact page index needs to be calculated by getting node info from the range cfi
                 var nodeRangeInfoFromCfi = this.getNodeRangeInfoFromCfi(partialCfi);
                 //the page index is calculated from the node's client rectangle
-                return findPageBySingleRectangle(nodeRangeInfoFromCfi.clientRect);
+                return findPageIndexDeltaBySingleRectangle(nodeRangeInfoFromCfi.clientRect);
             }
 
             var $element = getElementByPartialCfi(partialCfi, classBlacklist, elementBlacklist, idBlacklist);
@@ -986,7 +986,7 @@ var CfiNavigationLogic = function (options) {
                 return -1;
             }
 
-            return this.getPageIndexForElement($element);
+            return this.getPageIndexDeltaForElement($element);
         };
 
         function getElementByPartialCfi(cfi, classBlacklist, elementBlacklist, idBlacklist) {
@@ -1168,12 +1168,12 @@ var CfiNavigationLogic = function (options) {
             return getElementByPartialCfi(partialCfi, classBlacklist, elementBlacklist, idBlacklist);
         };
 
-        this.getPageIndexForElement = function ($element) {
+        this.getPageIndexDeltaForElement = function ($element) {
 
-            var pageIndex = findPageByRectangles($element);
+            var pageIndex = findPageIndexDeltaByRectangles($element);
             if (pageIndex === null) {
                 //Attempted to locate a hidden element, try a fallback with best guess
-                return findPageByRectangles(this.getNearestCfiFromElement($element[0]));
+                return findPageIndexDeltaByRectangles(this.getNearestCfiFromElement($element[0]));
             }
             return pageIndex;
         };
@@ -1192,14 +1192,14 @@ var CfiNavigationLogic = function (options) {
             return $element;
         };
 
-        this.getPageIndexForElementId = function (id) {
+        this.getPageIndexDeltaForElementId = function (id) {
 
             var $element = this.getElementById(id);
             if (!$element) {
                 return -1;
             }
 
-            return this.getPageIndexForElement($element);
+            return this.getPageIndexDeltaForElement($element);
         };
 
         // returns raw DOM element (not $ jQuery-wrapped)

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -795,11 +795,12 @@ var CfiNavigationLogic = function (options) {
             return height;
         }
 
-        function getTextRangeOffset(startingSet, visibleContentOffsets, directionBit,splitRatio, filterFunc) {
-
+        function getTextRangeOffset(startingSet, visibleContentOffsets, directionBit, splitRatio, filterFunc) {
+            var runCount = 0;
             var currRange = startingSet;
             //begin iterative binary search, each iteration will check Range length and visibility
-            while (currRange.length !=1) {
+            while (currRange.length !== 1) {
+                runCount++;
                 var currTextNodeFragments = getRangeClientRectList(currRange[directionBit], visibleContentOffsets);
                 if (hasVisibleFragments(currTextNodeFragments, filterFunc)) {
                     currRange = splitRange(currRange[directionBit], parseFloat(splitRatio));
@@ -809,6 +810,7 @@ var CfiNavigationLogic = function (options) {
                     currRange = splitRange(currRange[directionBit ? 0 : 1], parseFloat(splitRatio));
                 }
             }
+            if (DEBUG) console.debug('getVisibleTextRangeOffsets:getTextRangeOffset:runCount', runCount);
             return currRange[0];
         }
 

--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -806,7 +806,11 @@ var CfiNavigationLogic = function (options) {
                 console.debug('getVisibleTextRangeOffsets:getTextRangeOffset:runCount', runCount);
                 window.top._DEBUG_visibleTextRangeOffsetsRuns.push(runCount);
             }
-            return currRange[0];
+            var resultRange = currRange[0];
+            if (resultRange) {
+                resultRange.collapse(!directionBit);
+            }
+            return resultRange;
         }
 
         function hasVisibleFragments(fragments, filterFunc) {

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -862,6 +862,14 @@ var FixedView = function(options, reader){
         });
     };
 
+    this.getStartCfi = function () {
+        return getDisplayingViews()[0].getStartCfi();
+    };
+
+    this.getEndCfi = function () {
+        return getDisplayingViews()[0].getEndCfi();
+    };
+
     this.getNearestCfiFromElement = function(element) {
         var views = getDisplayingViews();
 

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -862,6 +862,19 @@ var FixedView = function(options, reader){
         });
     };
 
+    this.getNearestCfiFromElement = function(element) {
+        var views = getDisplayingViews();
+
+        for (var i = 0, count = views.length; i < count; i++) {
+
+            var view = views[i];
+            if (view.getLoadedContentFrames()[0].$iframe[0].contentDocument === element.ownerDocument) {
+                return view.getNearestCfiFromElement(element);
+            }
+        }
+
+    };
+
 };
     return FixedView;
 });

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -983,8 +983,8 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
     this.getNavigator = function () {
         return new CfiNavigationLogic({
             $iframe: _$iframe,
-            frameDimensions: getFrameDimensions,
-            visibleContentOffsets: getVisibleContentOffsets,
+            frameDimensionsGetter: getFrameDimensions,
+            visibleContentOffsetsGetter: getVisibleContentOffsets,
             classBlacklist: ["cfi-marker", "mo-cfi-highlight", "resize-sensor", "resize-sensor-expand", "resize-sensor-shrink", "resize-sensor-inner"],
             elementBlacklist: [],
             idBlacklist: ["MathJax_Message", "MathJax_SVG_Hidden"]

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -1124,6 +1124,10 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
         return self.getNavigator().getElementFromPoint(x, y);
     };
 
+
+    this.getNearestCfiFromElement = function(element) {
+        return createBookmarkFromCfi(self.getNavigator().getNearestCfiFromElement(element));
+    };
 };
 
 OnePageView.Events = {

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -974,9 +974,16 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
     }
     
     function getFrameDimensions() {
+        if (reader.needsFixedLayoutScalerWorkAround()) {
+            var parentEl = _$el.parent()[0];
+            return {
+                width: parentEl.clientWidth,
+                height: parentEl.clientHeight
+            };
+        }
         return {
-            width: _$el.parent()[0].clientWidth,
-            height: _$el.parent()[0].clientHeight
+            width: _meta_size.width,
+            height: _meta_size.height
         };
     }
     

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -1124,6 +1124,13 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
         return self.getNavigator().getElementFromPoint(x, y);
     };
 
+    this.getStartCfi = function () {
+        return createBookmarkFromCfi(self.getNavigator().getStartCfi());
+    };
+
+    this.getEndCfi = function () {
+        return createBookmarkFromCfi(self.getNavigator().getEndCfi());
+    };
 
     this.getNearestCfiFromElement = function(element) {
         return createBookmarkFromCfi(self.getNavigator().getNearestCfiFromElement(element));

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -1733,6 +1733,19 @@ var ReaderView = function (options) {
         }
         return undefined;
     };
+       
+    /**
+     * Useful for getting a CFI that's as close as possible to an invisible (not rendered, zero client rects) element
+     * @param {HTMLElement} element
+     * @returns {*}
+     */
+    this.getNearestCfiFromElement = function(element) {
+        if (_currentView) {
+            return _currentView.getNearestCfiFromElement(element);
+        }
+        return undefined;
+    };
+    
 };
 
 /**

--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -1628,6 +1628,29 @@ var ReaderView = function (options) {
         }
         return undefined;
     };
+
+    /**
+     * Get CFI of the first element from the base of the document
+     * @returns {ReadiumSDK.Models.BookmarkData}
+     */
+    this.getStartCfi = function() {
+        if (_currentView) {
+            return _currentView.getStartCfi();
+        }
+        return undefined;
+    };
+
+    /**
+     * Get CFI of the last element from the base of the document
+     * @returns {ReadiumSDK.Models.BookmarkData}
+     */
+    this.getEndCfi = function() {
+        if (_currentView) {
+            return _currentView.getEndCfi();
+        }
+        return undefined;
+    };
+
     /**
      *
      * @param {string} rangeCfi

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -1199,6 +1199,10 @@ var ReflowableView = function(options, reader){
     this.getElementFromPoint = function(x, y) {
         return _navigationLogic.getElementFromPoint(x,y);
     };
+
+    this.getNearestCfiFromElement = function(element) {
+        return createBookmarkFromCfi(_navigationLogic.getNearestCfiFromElement(element));
+    };
 };
     return ReflowableView;
 });

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -91,6 +91,7 @@ var ReflowableView = function(options, reader){
         columnMinWidth: 400,
         spreadCount : 0,
         currentSpreadIndex : 0,
+        currentPageIndex: 0,
         columnWidth : undefined,
         pageOffset : 0,
         columnCount: 0
@@ -243,6 +244,7 @@ var ReflowableView = function(options, reader){
 
             _paginationInfo.pageOffset = 0;
             _paginationInfo.currentSpreadIndex = 0;
+            _paginationInfo.currentPageIndex = 0;
             _currentSpineItem = spineItem;
             
             // TODO: this is a dirty hack!!
@@ -434,18 +436,18 @@ var ReflowableView = function(options, reader){
 
     }
 
-    this.openPageInternal = function(pageRequest) {
+    function _openPageInternal(pageRequest) {
 
         if(_isWaitingFrameRender) {
             _deferredPageRequest = pageRequest;
-            return;
+            return false;
         }
 
         // if no spine item specified we are talking about current spine item
         if(pageRequest.spineItem && pageRequest.spineItem != _currentSpineItem) {
             _deferredPageRequest = pageRequest;
             loadSpineItem(pageRequest.spineItem);
-            return;
+            return true;
         }
 
         var pageIndex = undefined;
@@ -455,9 +457,7 @@ var ReflowableView = function(options, reader){
             pageIndex = pageRequest.spineItemPageIndex;
         }
         else if(pageRequest.elementId) {
-            pageIndex = _navigationLogic.getPageIndexForElementId(pageRequest.elementId);
-            
-            if (pageIndex < 0) pageIndex = 0;
+            pageIndex = _paginationInfo.currentPageIndex + _navigationLogic.getPageIndexForElementId(pageRequest.elementId);
         }
         else if(pageRequest.firstVisibleCfi && pageRequest.lastVisibleCfi) {
             var firstPageIndex;
@@ -468,8 +468,6 @@ var ReflowableView = function(options, reader){
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);
-                
-                if (firstPageIndex < 0) firstPageIndex = 0;
             }
             catch (e)
             {
@@ -482,8 +480,6 @@ var ReflowableView = function(options, reader){
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);
-                
-                if (lastPageIndex < 0) lastPageIndex = 0;
             }
             catch (e)
             {
@@ -491,17 +487,15 @@ var ReflowableView = function(options, reader){
                 console.error(e);
             }
             // Go to the page in the middle of the two elements
-            pageIndex = Math.round((firstPageIndex + lastPageIndex) / 2);
+            pageIndex = _paginationInfo.currentPageIndex + Math.round((firstPageIndex + lastPageIndex) / 2);
         }
         else if(pageRequest.elementCfi) {
             try
             {
-                pageIndex = _navigationLogic.getPageIndexForCfi(pageRequest.elementCfi,
+                pageIndex = _paginationInfo.currentPageIndex + _navigationLogic.getPageIndexForCfi(pageRequest.elementCfi,
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);
-                
-                if (pageIndex < 0) pageIndex = 0;
             }
             catch (e)
             {
@@ -520,18 +514,20 @@ var ReflowableView = function(options, reader){
             pageIndex = 0;
         }
 
-        if(pageIndex >= 0 && pageIndex < _paginationInfo.columnCount) {
-            _paginationInfo.currentSpreadIndex = Math.floor(pageIndex / _paginationInfo.visibleColumnCount) ;
-            onPaginationChanged(pageRequest.initiator, pageRequest.spineItem, pageRequest.elementId);
-        }
-        else {
+        if (pageIndex < 0 || pageIndex > _paginationInfo.columnCount) {
             console.log('Illegal pageIndex value: ', pageIndex, 'column count is ', _paginationInfo.columnCount);
+            pageIndex = pageIndex < 0 ? 0 : _paginationInfo.columnCount;
         }
-    };
+
+        _paginationInfo.currentPageIndex = pageIndex;
+        _paginationInfo.currentSpreadIndex = Math.floor(pageIndex / _paginationInfo.visibleColumnCount) ;
+        onPaginationChanged(pageRequest.initiator, pageRequest.spineItem, pageRequest.elementId);
+        return true;
+    }
 
     this.openPage = function(pageRequest) {
         // Go to request page, it will save the new position in onPaginationChanged
-        this.openPageInternal(pageRequest);
+        _openPageInternal(pageRequest);
         // Save it for when pagination is updated
         _lastPageRequest = pageRequest;
     };
@@ -555,7 +551,7 @@ var ReflowableView = function(options, reader){
 
     this.restoreCurrentPosition = function() {
         if (_lastPageRequest) {
-            this.openPageInternal(_lastPageRequest);            
+            _openPageInternal(_lastPageRequest);
         }
     };
 
@@ -600,7 +596,7 @@ var ReflowableView = function(options, reader){
     }
 
     function onPaginationChanged_(initiator, paginationRequest_spineItem, paginationRequest_elementId) {
-
+        _paginationInfo.currentPageIndex = _paginationInfo.currentSpreadIndex * _paginationInfo.visibleColumnCount;
         _paginationInfo.pageOffset = (_paginationInfo.columnWidth + _paginationInfo.columnGap) * _paginationInfo.visibleColumnCount * _paginationInfo.currentSpreadIndex;
         
         redraw();
@@ -861,6 +857,7 @@ var ReflowableView = function(options, reader){
             if (_lastPageRequest) {
                 // Make sure we stay on the same page after the content or the viewport 
                 // has been resized
+                _paginationInfo.currentPageIndex = 0; // current page index is not stable, reset it
                 self.restoreCurrentPosition();
             } else {
                 onPaginationChanged(self); // => redraw() => showBook(), so the trick below is not needed                

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -176,6 +176,27 @@ var ReflowableView = function(options, reader){
         };
     }
 
+    function getPageOffset() {
+        if (_paginationInfo.rightToLeft && !_paginationInfo.isVerticalWritingMode) {
+            return -_paginationInfo.pageOffset;
+        }
+        return _paginationInfo.pageOffset;
+    }
+
+    function getPaginationOffsets() {
+        var offset = getPageOffset();
+        if (_paginationInfo.isVerticalWritingMode) {
+            return {
+                top: offset,
+                left: 0
+            };
+        }
+        return {
+            top: 0,
+            left: offset
+        };
+    }
+
     function renderIframe() {
         if (_$contentFrame) {
             //destroy old contentFrame
@@ -198,8 +219,9 @@ var ReflowableView = function(options, reader){
 
         _navigationLogic = new CfiNavigationLogic({
             $iframe: _$iframe,
-            frameDimensions: getFrameDimensions,
+            frameDimensionsGetter: getFrameDimensions,
             paginationInfo: _paginationInfo,
+            paginationOffsetsGetter: getPaginationOffsets,
             classBlacklist: _cfiClassBlacklist,
             elementBlacklist: _cfiElementBlacklist,
             idBlacklist: _cfiIdBlacklist
@@ -433,7 +455,7 @@ var ReflowableView = function(options, reader){
             pageIndex = pageRequest.spineItemPageIndex;
         }
         else if(pageRequest.elementId) {
-            pageIndex = _navigationLogic.getPageForElementId(pageRequest.elementId);
+            pageIndex = _navigationLogic.getPageIndexForElementId(pageRequest.elementId);
             
             if (pageIndex < 0) pageIndex = 0;
         }
@@ -442,7 +464,7 @@ var ReflowableView = function(options, reader){
             var lastPageIndex;
             try
             {
-                firstPageIndex = _navigationLogic.getPageForElementCfi(pageRequest.firstVisibleCfi,
+                firstPageIndex = _navigationLogic.getPageIndexForCfi(pageRequest.firstVisibleCfi,
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);
@@ -456,7 +478,7 @@ var ReflowableView = function(options, reader){
             }
             try
             {
-                lastPageIndex = _navigationLogic.getPageForElementCfi(pageRequest.lastVisibleCfi,
+                lastPageIndex = _navigationLogic.getPageIndexForCfi(pageRequest.lastVisibleCfi,
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);
@@ -474,7 +496,7 @@ var ReflowableView = function(options, reader){
         else if(pageRequest.elementCfi) {
             try
             {
-                pageIndex = _navigationLogic.getPageForElementCfi(pageRequest.elementCfi,
+                pageIndex = _navigationLogic.getPageIndexForCfi(pageRequest.elementCfi,
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -457,14 +457,14 @@ var ReflowableView = function(options, reader){
             pageIndex = pageRequest.spineItemPageIndex;
         }
         else if(pageRequest.elementId) {
-            pageIndex = _paginationInfo.currentPageIndex + _navigationLogic.getPageIndexForElementId(pageRequest.elementId);
+            pageIndex = _paginationInfo.currentPageIndex + _navigationLogic.getPageIndexDeltaForElementId(pageRequest.elementId);
         }
         else if(pageRequest.firstVisibleCfi && pageRequest.lastVisibleCfi) {
             var firstPageIndex;
             var lastPageIndex;
             try
             {
-                firstPageIndex = _navigationLogic.getPageIndexForCfi(pageRequest.firstVisibleCfi,
+                firstPageIndex = _navigationLogic.getPageIndexDeltaForCfi(pageRequest.firstVisibleCfi,
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);
@@ -476,7 +476,7 @@ var ReflowableView = function(options, reader){
             }
             try
             {
-                lastPageIndex = _navigationLogic.getPageIndexForCfi(pageRequest.lastVisibleCfi,
+                lastPageIndex = _navigationLogic.getPageIndexDeltaForCfi(pageRequest.lastVisibleCfi,
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);
@@ -492,7 +492,7 @@ var ReflowableView = function(options, reader){
         else if(pageRequest.elementCfi) {
             try
             {
-                pageIndex = _paginationInfo.currentPageIndex + _navigationLogic.getPageIndexForCfi(pageRequest.elementCfi,
+                pageIndex = _paginationInfo.currentPageIndex + _navigationLogic.getPageIndexDeltaForCfi(pageRequest.elementCfi,
                     _cfiClassBlacklist,
                     _cfiElementBlacklist,
                     _cfiIdBlacklist);

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -1172,6 +1172,14 @@ var ReflowableView = function(options, reader){
         return createBookmarkFromCfi(_navigationLogic.getLastVisibleCfi());
     };
 
+    this.getStartCfi = function () {
+        return createBookmarkFromCfi(_navigationLogic.getStartCfi());
+    };
+
+    this.getEndCfi = function () {
+        return createBookmarkFromCfi(_navigationLogic.getEndCfi());
+    };
+
     this.getDomRangeFromRangeCfi = function (rangeCfi, rangeCfi2, inclusive) {
         if (rangeCfi2 && rangeCfi.idref !== rangeCfi2.idref) {
             console.error("getDomRangeFromRangeCfi: both CFIs must be scoped under the same spineitem idref");

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -1354,37 +1354,24 @@ var ScrollView = function (options, isContinuousScroll, reader) {
     function getFirstOrLastVisibleCfi(pickerFunc) {
         var pageViews = getVisiblePageViews();
         var selectedPageView = pickerFunc(pageViews);
-        var pageViewTopOffset = selectedPageView.element().position().top;
+        var pageViewTopOffset =selectedPageView.element().position().top;
         var visibleContentOffsets, frameDimensions;
-        
-        var setupFunctions = [
-            function () {
-                visibleContentOffsets = {
-                    top: pageViewTopOffset,
-                    left: 0
-                };
-            },
-            function() {
-                var height = selectedPageView.element().height();
-                
-                if (pageViewTopOffset >= 0) {
-                    height = viewHeight() - pageViewTopOffset;
-                }
 
-                frameDimensions = {
-                    width: selectedPageView.element().width(),
-                    height: height
-                };
-                
-                visibleContentOffsets = {
-                    top: 0,
-                    left: 0
-                };
-            }
-        ];
+        visibleContentOffsets = {
+            top:  Math.min(0, pageViewTopOffset),
+            left: 0
+        };
+
+        var height = Math.min(selectedPageView.element().height(), viewHeight());
+
+        if (pageViewTopOffset >= 0) {
+            height = height - pageViewTopOffset;
+        }
         
-        //invoke setup function
-        pickerFunc(setupFunctions)();
+        frameDimensions = {
+            width: selectedPageView.element().width(),
+            height: height
+        };
         
         var cfiFunctions = [
             selectedPageView.getFirstVisibleCfi,

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -1407,6 +1407,10 @@ var ScrollView = function (options, isContinuousScroll, reader) {
         });
     };
 
+    function createBookmarkFromCfi(currentSpineItem, cfi){
+        return new BookmarkData(currentSpineItem.idref, cfi);
+    }
+
     this.getRangeCfiFromDomRange = function (domRange) {
         return callOnVisiblePageView(function (pageView) {
             return pageView.getRangeCfiFromDomRange(domRange);
@@ -1437,9 +1441,11 @@ var ScrollView = function (options, isContinuousScroll, reader) {
         });
     };
 
-    function createBookmarkFromCfi(currentSpineItem, cfi){
-        return new BookmarkData(currentSpineItem.idref, cfi);
-    }
+    this.getNearestCfiFromElement = function (element) {
+        return callOnVisiblePageView(function (pageView) {
+            return pageView.getNearestCfiFromElement(element);
+        });
+    };
 };
 
 return ScrollView;

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -1441,6 +1441,18 @@ var ScrollView = function (options, isContinuousScroll, reader) {
         });
     };
 
+    this.getStartCfi = function () {
+        return callOnVisiblePageView(function (pageView) {
+            return pageView.getStartCfi();
+        });
+    };
+
+    this.getEndCfi = function () {
+        return callOnVisiblePageView(function (pageView) {
+            return pageView.getEndCfi();
+        });
+    };
+
     this.getNearestCfiFromElement = function (element) {
         return callOnVisiblePageView(function (pageView) {
             return pageView.getNearestCfiFromElement(element);

--- a/js/views/scroll_view.js
+++ b/js/views/scroll_view.js
@@ -1428,20 +1428,20 @@ var ScrollView = function (options, isContinuousScroll, reader) {
 
     this.getVisibleCfiFromPoint = function (x, y, precisePoint) {
         return callOnVisiblePageView(function (pageView) {
-            return createBookmark(pageView.currentSpineItem(), pageView.getVisibleCfiFromPoint(x, y, precisePoint));
+            return createBookmarkFromCfi(pageView.currentSpineItem(), pageView.getVisibleCfiFromPoint(x, y, precisePoint));
         });
     };
 
     this.getRangeCfiFromPoints = function (startX, startY, endX, endY) {
         return callOnVisiblePageView(function (pageView) {
-            return createBookmark(pageView.currentSpineItem(), pageView.getRangeCfiFromPoints(startX, startY, endX, endY));
+            return createBookmarkFromCfi(pageView.currentSpineItem(), pageView.getRangeCfiFromPoints(startX, startY, endX, endY));
         });
     };
 
     this.getCfiForElement = function(element) {
         return callOnVisiblePageView(function (pageView) {
-            return createBookmark(pageView.currentSpineItem(), pageView.getCfiForElement(element));
-        });
+            return createBookmarkFromCfi(pageView.currentSpineItem(), pageView.getCfiForElement(element).contentCFI);
+        })
     };
 
     this.getElementFromPoint = function (x, y) {
@@ -1449,6 +1449,10 @@ var ScrollView = function (options, isContinuousScroll, reader) {
             return pageView.getElementFromPoint(x, y);
         });
     };
+
+    function createBookmarkFromCfi(currentSpineItem, cfi){
+        return new BookmarkData(currentSpineItem.idref, cfi);
+    }
 };
 
 return ScrollView;

--- a/plugins/highlights/controller.js
+++ b/plugins/highlights/controller.js
@@ -53,9 +53,7 @@ function($, _, Class, HighlightHelpers, HighlightGroup) {
         redraw: function() {
             var that = this;
 
-            var leftAddition = -this._getPaginationLeftOffset();
-            
-            var isVerticalWritingMode = this.context.paginationInfo().isVerticalWritingMode;
+            var paginationOffsets = this._getPaginationOffsets();
 
             var visibleCfiRange = this.getVisibleCfiRange();
 
@@ -75,11 +73,7 @@ function($, _, Class, HighlightHelpers, HighlightGroup) {
                         visibleCfiRange.lastVisibleCfi.contentCFI);
                 }
                 highlightGroup.visible = visible;
-                highlightGroup.resetHighlights(that.readerBoundElement,
-                    isVerticalWritingMode ? leftAddition : 0,
-                    isVerticalWritingMode ? 0 : leftAddition
-                    );
-
+                highlightGroup.resetHighlights(that.readerBoundElement, paginationOffsets.top, paginationOffsets.left);
             });
         },
 
@@ -151,10 +145,7 @@ function($, _, Class, HighlightHelpers, HighlightGroup) {
         addHighlight: function(CFI, id, type, styles) {
             var CFIRangeInfo;
             var range;
-            var rangeStartNode;
-            var rangeEndNode;
             var selectedElements;
-            var leftAddition;
 
             var contentDoc = this.context.document;
             //get transform scale of content document
@@ -208,16 +199,12 @@ function($, _, Class, HighlightHelpers, HighlightGroup) {
                 range = null;
             }
 
-            leftAddition = -this._getPaginationLeftOffset();
-
-            var isVerticalWritingMode = this.context.paginationInfo().isVerticalWritingMode;
+            var paginationOffsets = this._getPaginationOffsets();
 
             this._addHighlightHelper(
                 CFI, id, type, styles, selectedElements, range,
-                startNode, endNode,
-                isVerticalWritingMode ? leftAddition : 0,
-                isVerticalWritingMode ? 0 : leftAddition
-                );
+                startNode, endNode, paginationOffsets.top, paginationOffsets.left
+            );
 
             return {
                 selectedElements: selectedElements,
@@ -429,7 +416,7 @@ function($, _, Class, HighlightHelpers, HighlightGroup) {
             var selectedElements = [];
 
             if (!elementType) {
-                var elementType = ["text"];
+                elementType = ["text"];
             }
 
             this._findSelectedElements(
@@ -558,24 +545,31 @@ function($, _, Class, HighlightHelpers, HighlightGroup) {
             }
         },
 
-        _getPaginationLeftOffset: function() {
-        
-            var $htmlElement = $(this.context.document.documentElement);
-            if (!$htmlElement || !$htmlElement.length) {
-                // if there is no html element, we might be dealing with a fxl with a svg spine item
-                return 0;
+        _getPaginationOffsets: function() {
+            if (!this.context.paginationInfo) {
+                return {
+                    top: 0,
+                    left: 0
+                }
             }
 
-            var offsetLeftPixels = $htmlElement.css(this.context.paginationInfo().isVerticalWritingMode ? "top" : (this.context.isRTL ? "right" : "left"));
-            var offsetLeft = parseInt(offsetLeftPixels.replace("px", ""));
-            if (isNaN(offsetLeft)) {
-                //for fixed layouts, $htmlElement.css("left") has no numerical value
-                offsetLeft = 0;
+            var offset;
+            if (this.context.isRTL && !this.context.isVerticalWritingMode) {
+                offset = -this.context.paginationInfo.pageOffset;
+            } else {
+                offset = this.context.paginationInfo.pageOffset;
             }
-            
-            if (this.context.isRTL && !this.context.paginationInfo().isVerticalWritingMode) return -offsetLeft;
-             
-            return offsetLeft;
+
+            if (this.context.isVerticalWritingMode) {
+                return {
+                    top: offset,
+                    left: 0
+                };
+            }
+            return {
+                top: 0,
+                left: offset
+            };
         },
 
         _injectAnnotationCSS: function(annotationCSSUrl) {


### PR DESCRIPTION
Improves general CFI functionality.
Fixes #384, #386. #353, #294 

Introduces new Reader API calls:
`getStartCfi` - Get CFI of the first element from the base of the document
`getEndCfi` - Get CFI of the last element from the base of the document
`getNearestCfiFromElement` - Useful for getting a CFI that's as close as possible to an invisible (not rendered, zero client rects) element

Ran auto & manual tests to verify improvements with no regressions in the CFI area with focus on:
- Reflowable view
  - Right to left
  - Vertical text
- Scroll view doc & continuous


This PR also changes the way first/last visible CFI using text offsets are generated. Now they are based on a collapsed range when appropriate.
Example:

> Previously a CFI anchor was generated with a 1 character offset:
> First: `/4/2[introduction]/2,/1:0,/1:1`
> Last: `/4/2[introduction]/14,/1:223,/1:224`
> 
> Now this anchor is still a single character but the start and end being the same start offset, hence a collapsed range or “caret” range
> First: `/4/2[introduction]/2/1:0`
> Last: `/4/2[introduction]/14/1:224`

#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
Most likely fixes or improves the state of these issues:
#388 
#384
#386 
#345 
#353 
#294 
#269 
#230 
