### PR TITLE
Remove left over code from touchInit method

### DIFF
--- a/js/views/media_overlay_player.js
+++ b/js/views/media_overlay_player.js
@@ -930,14 +930,7 @@ var MediaOverlayPlayer = function(reader, onStatusChanged) {
 
     this.touchInit = function()
     {
-        var todo = _audioPlayer.touchInit();
-        if (todo)
-        {
-            if (_enableHTMLSpeech)
-            {
-                speakStart("o", 0);
-            }
-        }
+        return _audioPlayer.touchInit();
     };
 
     var tokeniseTTS = function(element)


### PR DESCRIPTION
This (what seems to be) left over todo code is causing an issue when using this method of the media overlay and audio player. It is speaking out the letter 'O' whenever it gets called. We use this method in an app for iOS to get past a strange iOS 'security' quirk

#### This pull request is Finalized

#### Related issue(s) and/or pull request(s)
#400

