### PR TITLE
Fix rectangle visibility check in cfi navigation logic for scroll view

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -509,9 +509,9 @@ var CfiNavigationLogic = function (options) {
                 width: textRect.right - textRect.left,
                 height: textRect.bottom - textRect.top
             };
-            if (leftOffset && topOffset) {
-                offsetRectangle(plainRectObject, leftOffset, topOffset);
-            }
+            leftOffset = leftOffset || 0;
+            topOffset = topOffset || 0;
+            offsetRectangle(plainRectObject, leftOffset, topOffset);
             return plainRectObject;
         }
 


### PR DESCRIPTION
#### This pull request is a Work In Progress

#### Related issue(s) and/or pull request(s)
Issue #405

### Additional information
The value of leftOffset is zero when this logic is invoked through ScrollView, so the `offsetRectangle` call is always skipped. Always applying the offsets works in my testing using scroll and reflowable views, and is the logic in this function in master. Coercing the offset values may not be needed, but maybe achieves the intention of the `if (leftOffset && topOffset)` check?

I didn't test all paths (say, from `getFirstVisibleCfi` or `getLastVisibleCfi`), but I didn't spot anything when reading through these.
