### PR TITLE
Add guards and extra robustness to the internals of bookmarkCurrentPage

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -47,14 +47,21 @@ var CfiNavigationLogic = function (options) {
     }
 
     this.getRootElement = function () {
+        if (!options.$iframe) {
+            return null;
+        }
 
         return options.$iframe[0].contentDocument.documentElement;
     };
 
     this.getBodyElement = function () {
-
-        // In SVG documents the root element can be considered the body.
-        return this.getRootDocument().body || this.getRootElement();
+        var rootDocument = this.getRootDocument();
+        if (rootDocument && rootDocument.body) {
+            return rootDocument.body;
+        } else {
+            // In SVG documents the root element can be considered the body.
+            return this.getRootElement();
+        }
     };
 
     this.getClassBlacklist = function () {
@@ -70,6 +77,10 @@ var CfiNavigationLogic = function (options) {
     };
 
     this.getRootDocument = function () {
+        if (!options.$iframe) {
+            return null;
+        }
+
         return options.$iframe[0].contentDocument;
     };
 
@@ -1572,7 +1583,7 @@ var CfiNavigationLogic = function (options) {
                 var arr = window.top._DEBUG_visibleTextRangeOffsetsRuns;
                 return arr.reduce(function (a, b) {
                     return a + b;
-                }) / arr.length;             
+                }) / arr.length;
             }
         };
 
@@ -1581,12 +1592,18 @@ var CfiNavigationLogic = function (options) {
 
         this.findFirstVisibleElement = function (visibleContentOffsets, frameDimensions) {
 
+            var bodyElement = this.getBodyElement();
+
+            if (!bodyElement) {
+                return null;
+            }
+
             var firstVisibleElement;
             var percentVisible = 0;
             var textNode;
 
             var treeWalker = document.createTreeWalker(
-                this.getBodyElement(),
+                bodyElement,
                 NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
                 function(node) {
                     if (node.nodeType === Node.ELEMENT_NODE && isElementBlacklisted(node))
@@ -1658,12 +1675,18 @@ var CfiNavigationLogic = function (options) {
 
         this.findLastVisibleElement = function (visibleContentOffsets, frameDimensions) {
 
+            var bodyElement = this.getBodyElement();
+
+            if (!bodyElement) {
+                return null;
+            }
+
             var firstVisibleElement;
             var percentVisible = 0;
             var textNode;
 
             var treeWalker = document.createTreeWalker(
-                this.getBodyElement(),
+                bodyElement,
                 NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT,
                 function(node) {
                     if (node.nodeType === Node.ELEMENT_NODE && isElementBlacklisted(node))

--- a/js/views/fixed_view.js
+++ b/js/views/fixed_view.js
@@ -594,10 +594,12 @@ var FixedView = function(options, reader){
     this.bookmarkCurrentPage = function() {
 
         var views = getDisplayingViews();
+        var loadedSpineItems = this.getLoadedSpineItems();
 
-        if(views.length > 0) {
-
+        if (views.length > 0) {
             return views[0].getFirstVisibleCfi();
+        } else if (loadedSpineItems.length > 0) {
+            return new BookmarkData(this.getLoadedSpineItems()[0].idref, null);
         }
 
         return undefined;

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -1084,7 +1084,11 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
         return navigation.getNodeRangeInfoFromCfi(partialCfi);
     };
 
-    function createBookmarkFromCfi(cfi){
+    function createBookmarkFromCfi(cfi) {
+        if (!_currentSpineItem) {
+            return null;
+        }
+
         return new BookmarkData(_currentSpineItem.idref, cfi);
     }
 


### PR DESCRIPTION
Related to https://github.com/readium/readium-js-viewer/pull/647

This prevents errors from being thrown when the user of the function invokes it when the spine item plus nav logic is not fully initialized yet.
For this case. the BookmarkData result would include the intended spine item idref but with a `null` CFI

#### How to test this:
Place a breakpoint or create an event handler for `CONTENT_DOCUMENT_LOAD_START`
and make it call `reader.bookmarkCurrentPage()` there should be a result (without error) with `{idref:"xyz", contentCFI: null}`. This should be consistent with Reflowable, Fixed, and Scroll view types.
