### PR TITLE
Skip externalAgentSupport call when spineItem not available

### DIFF
--- a/js/views/reader_view.js
+++ b/js/views/reader_view.js
@@ -280,6 +280,8 @@ var ReaderView = function (options) {
             _.defer(function () {
                 Globals.logEvent("PAGINATION_CHANGED", "EMIT", "reader_view.js");
                 self.emit(Globals.Events.PAGINATION_CHANGED, pageChangeData);
+                
+                if (!pageChangeData.spineItem) return;
                 _.defer(function () {
                     _externalAgentSupport.updateContentDocument(pageChangeData.spineItem);
                 });


### PR DESCRIPTION
#### This pull request is a Work In Progress

#### Related issue(s) and/or pull request(s)
Issue #407

Alternately, ensure that spineItem is always populated?

ReflowableView:863
ScrollView:281
ScrollView:554
FixedView:200
