### PR TITLE
Fix bookmark restoration on Safari

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -103,7 +103,16 @@ var CfiNavigationLogic = function (options) {
         } else if (endNode.nodeType === Node.TEXT_NODE) {
             range.setEnd(endNode, endOffset ? endOffset : 0);
         }
-        return normalizeRectangle(range.getBoundingClientRect(), 0, 0);
+
+        // Webkit has a bug where collapsed ranges provide an empty rect with getBoundingClientRect()
+        // https://bugs.webkit.org/show_bug.cgi?id=138949
+        // Thankfully it implements getClientRects() properly...
+        // A collapsed text range may still have geometry!
+        if (range.collapsed) {
+            return normalizeRectangle(range.getClientRects()[0], 0, 0);
+        } else {
+            return normalizeRectangle(range.getBoundingClientRect(), 0, 0);
+        }
     }
 
     function getNodeClientRectList(node, visibleContentOffsets) {


### PR DESCRIPTION
Fix a bug that returns empty rects from collapsed ranges that have actual rect data.

This is a workaround fix for a WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=138949

This bug prevented restoring CFI bookmark locations on Safari!

### How to test this:
- Attempt to restore a bookmark where the CFI has a text offset step targeting the start of a character:
`/4/2/140/1:0`

#### Method 1
1. Open the 'Moby Dick' sample in the Readium Cloud Reader here:
https://readium.firebaseapp.com/?epub=epub_content%2Fmoby_dick
2. In the Web Dev Tools > Console, enter this line of JS:  
```js
window.top.ReadiumSDK.reader.openSpineItemElementCfi('xchapter_003',
 '/4/2/140/1:0');
```
3. It should take you to the end of Chapter 3. The observed behaviour in Safari is that it takes you to the start of the chapter no matter the CFI.

#### Method 2
1. Open this link: https://readium.firebaseapp.com/?epub=epub_content%2Fmoby_dick&goto=%7B%22idref%22%3A%22xchapter_003%22%2C%22elementCfi%22%3A%22%2F4%2F2%2F130%2F1%3A0%22%7D&
2. It should take you to the end of the chapter. If it doesn't but it takes you close to the end the chapter then you reproduced the issue behind #412. If it shows you the start of the chapter then you reproduced this issue.

#### This pull request is Finalized
