### PR TITLE
Fix the ResizeSensor by forcing the content doc body to be "positioned"

### DIFF
--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -792,6 +792,11 @@ var ReflowableView = function(options, reader){
         _$epubHtml.css('margin', 0);
         _$epubHtml.css('padding', 0);
         _$epubHtml.css('border', 0);
+
+        // In order for the ResizeSensor to work, the content body needs to be "positioned".
+        // This may be an issue since it changes the assumptions some content authors might make when positioning their content.
+        _$htmlBody.css('position', 'relative');
+
         _$htmlBody.css('margin', 0);
         _$htmlBody.css('padding', 0);
 


### PR DESCRIPTION
This will make it so content document body elements have the CSS style `position: relative` always applied, but only for reflowable documents.

We use the ResizeSensor to target the body of the content doc, to get an event for whenever content reflows or resizes.

The third-party ResizeSensor module wants to set its target element's `position` style to be `relative` as it is key to its functionality.

Unfortunately the condition that checked for this no longer applies to our usage's target element being the 'body'.
It used to check the target element's computed style for position, see if it’s `static` and then change it to `relative`.
As of this merge it no longer does the check in the same way:
https://github.com/marcj/css-element-queries/pull/172

Now it checks the ‘offsetParent’ property of the resize sensor container element, if the offsetParent is not the target element then it applies the ‘relative’ value.
From what I’ve seen by inspecting things with Chrome, looking at the live DOM of the content documents, even if the body has ‘relative’ or not, it by default is the ‘offsetParent’ of the resize sensor element. This means that after this merge the `position: relative` that’s needed is no longer applied.

#### This pull request is Finalized
