### PR TITLE
Fix a regression in the implementation of `.insureElementVisibility`

### DIFF
--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -1074,15 +1074,15 @@ var ReflowableView = function(options, reader){
             return;
         }
 
-        var page = _navigationLogic.getPageForElement($element);
+        var elementCfi = _navigationLogic.getCfiForElement(element);
 
-        if(page == -1)
+        if (!elementCfi)
         {
             return;
         }
 
         var openPageRequest = new PageOpenRequest(_currentSpineItem, initiator);
-        openPageRequest.setPageIndex(page);
+        openPageRequest.setElementCfi(elementCfi);
 
         var id = element.id;
         if (!id)


### PR DESCRIPTION
Fixes #416

Media overlay player needs to be tested for this.