### PR TITLE
fixed layout document body margin reset to zero

### DIFF
--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -377,6 +377,10 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
                 _$epubBody = undefined;
             } else {
                 _$epubBody = $("body", _$epubHtml);
+
+                if (!_enableBookStyleOverrides) { // fixed layout
+                    _$epubBody.css("margin", "0"); // ensures 8px margin default user agent stylesheet is reset to zero
+                }
             }
 
             //_$epubHtml.css("overflow", "hidden");


### PR DESCRIPTION
… to ensure user stylesheet doesn't set default 8px margin all around

Fixes:
https://github.com/readium/readium-js-viewer/issues/673#event-1345872614
