### PR TITLE
Extend `buildUrlQueryParameters` helper

### DIFF
--- a/js/views/iframe_loader.js
+++ b/js/views/iframe_loader.js
@@ -26,7 +26,7 @@
 //  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
-define(["jquery", "underscore"], function($, _) {
+define(["jquery", "underscore", 'URIjs'], function($, _, URI) {
 /**
  *
  * @constructor

--- a/js/views/internal_links_support.js
+++ b/js/views/internal_links_support.js
@@ -22,7 +22,7 @@
 //  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
 //  OF THE POSSIBILITY OF SUCH DAMAGE.
 
-define(['jquery', '../helpers', 'readium_cfi_js'], function($, Helpers, epubCfi) {
+define(['jquery', '../helpers', 'readium_cfi_js', 'URIjs'], function($, Helpers, epubCfi, URI) {
 /**
  *
  * @param reader


### PR DESCRIPTION
Partial rewrite of `buildUrlQueryParameters` helper to support the preservation of query strings in the initial URL as well as the hash fragment.

The overrides feature now also has a way to control the escaping of a supplied param value.

Example usage:
```js
Helpers.buildUrlQueryParameters('http://example.com?preservedQuery1=test#helloWorld', {
  // characters will be escaped by helper
  epub: 'some/path/to/epub', 
  // no escaping applied by helper for the following
  goto: {
    value: encodeURI('epubcfi(/6/2!4/2/2[text_assert])'),
    verbatim: true
  } 
});
```
Output:
> `http://example.com/?epub=some%2Fpath%2Fto%2Fepub&goto=epubcfi(/6/2!4/2/2%5Btext_assert%5D)&preservedQuery1=test#helloWorld`