### PR TITLE
Add more conditions in the CFI blacklisting for Hypothes.is elements

### DIFF
--- a/js/views/cfi_navigation_logic.js
+++ b/js/views/cfi_navigation_logic.js
@@ -1369,6 +1369,10 @@ var CfiNavigationLogic = function (options) {
                 return true;
             }
 
+            if (_.contains(self.getElementBlacklist(), element.tagName.toLowerCase())) {
+                return true;
+            }
+
             return false;
         }
 

--- a/js/views/one_page_view.js
+++ b/js/views/one_page_view.js
@@ -996,8 +996,8 @@ var OnePageView = function (options, classes, enableBookStyleOverrides, reader) 
             $iframe: _$iframe,
             frameDimensionsGetter: getFrameDimensions,
             visibleContentOffsetsGetter: getVisibleContentOffsets,
-            classBlacklist: ["cfi-marker", "mo-cfi-highlight", "resize-sensor", "resize-sensor-expand", "resize-sensor-shrink", "resize-sensor-inner"],
-            elementBlacklist: [],
+            classBlacklist: ["cfi-marker", "mo-cfi-highlight", "resize-sensor", "resize-sensor-expand", "resize-sensor-shrink", "resize-sensor-inner", "js-hypothesis-config", "js-hypothesis-embed"],
+            elementBlacklist: ["hypothesis-adder"],
             idBlacklist: ["MathJax_Message", "MathJax_SVG_Hidden"]
         });
     };

--- a/js/views/reflowable_view.js
+++ b/js/views/reflowable_view.js
@@ -60,8 +60,8 @@ var ReflowableView = function(options, reader){
     var _$epubHtml;
     var _lastPageRequest = undefined;
 
-    var _cfiClassBlacklist = ["cfi-marker", "mo-cfi-highlight", "resize-sensor", "resize-sensor-expand", "resize-sensor-shrink", "resize-sensor-inner"];
-    var _cfiElementBlacklist = [];
+    var _cfiClassBlacklist = ["cfi-marker", "mo-cfi-highlight", "resize-sensor", "resize-sensor-expand", "resize-sensor-shrink", "resize-sensor-inner", "js-hypothesis-config", "js-hypothesis-embed"];
+    var _cfiElementBlacklist = ["hypothesis-adder"];
     var _cfiIdBlacklist = ["MathJax_Message", "MathJax_SVG_Hidden"];
 
     var _$htmlBody;


### PR DESCRIPTION
Hypothes.is adds more elements to the content DOM that get picked up by the CFI logic.

`<script xmlns="http://www.w3.org/1999/xhtml" class="js-hypothesis-config" type="application/json">`
`<script xmlns="http://www.w3.org/1999/xhtml" class="js-hypothesis-embed" async="" src="https://cdn.hypothes.is/hypothesis/1.61.0/build/boot.js">`
`<hypothesis-adder>`

This amends the blacklist and adds the missing implementation of element (tag name) blacklisting in CFI nav logic.