### PR TITLE
Prevent setting a font size on an element without the original font size

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -361,8 +361,10 @@ Helpers.UpdateHtmlFontAttributes = function ($epubHtml, fontSize, fontObj, callb
             // TODO: group the 3x potential $(ele).css() calls below to avoid multiple jQuery style mutations 
 
             var fontSizeAttr = ele.getAttribute('data-original-font-size');
-            var originalFontSize = Number(fontSizeAttr);
-            $(ele).css("font-size", (originalFontSize * factor) + 'px');
+            var originalFontSize = fontSizeAttr ? Number(fontSizeAttr) : 0;
+            if (originalFontSize) {
+                $(ele).css("font-size", (originalFontSize * factor) + 'px');
+            }
 
             var lineHeightAttr = ele.getAttribute('data-original-line-height');
             var originalLineHeight = lineHeightAttr ? Number(lineHeightAttr) : 0;


### PR DESCRIPTION
This is an issue regarding `Helpers.UpdateHtmlFontAttributes`
There are some elements that get added on a document that somehow miss the pass that sets the `data-original-font-size` attribute. This is common when dealing with MathJax elements.

There is a bug with the implementation of the helper function that causes the font size of those elements to be set to 0px. This is because the original font size was not set for those elements and the empty attribute is interpreted as if the element had a font size of "0".

The font-size ending up being set as 0px on these elements causes issues with MathJax element rendering.

It's difficult to reproduce this issue. The best info I can give is load a MathJax heavy chapter and change the font size up and down, doing that quickly seems to break the rendering. The MathJax elements should end up looking collapsed or invisible.
  